### PR TITLE
Add auth header to data request

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ PROJECT_ID=<name of the Google Cloud project>
 AFL_DATA_SERVICE=<hostname of the afl data service>
 GOOGLE_APPLICATION_CREDENTIALS=<filepath of the Google Cloud credentials JSON>
 GCPF_TOKEN=<authorization token for making calls to the data science functions>
+GCR_TOKEN=<authorization token for making calls to the afl data functions>

--- a/env.js
+++ b/env.js
@@ -7,6 +7,7 @@ module.exports.env = () => (
     project: process.env.PROJECT_ID,
     credentials: path.resolve(__dirname, process.env.GOOGLE_APPLICATION_CREDENTIALS),
     gcpf_token: process.env.GCPF_TOKEN,
+    gcr_token: process.env.GCR_TOKEN,
     afl_data_service: process.env.AFL_DATA_SERVICE,
   }
 )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,7 @@ docker run \
   -e AFL_DATA_SERVICE=${AFL_DATA_SERVICE} \
   -e GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS} \
   -e GCPF_TOKEN=${GCPF_TOKEN} \
+  -e GCR_TOKEN=${GCR_TOKEN} \
   -v ${HOME}/.gcloud:/app/.gcloud \
   cfranklin11/tipresias_data_science:latest \
   sls deploy

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
     AFL_DATA_SERVICE: ${self:custom.afl_data_service}
     PYTHON_ENV: production
     GCPF_TOKEN: ${self:custom.gcpf_token}
+    GCR_TOKEN: ${self:custom.gcr_token}
     PYTHONPATH: ./src
 
 plugins:

--- a/src/machine_learning/data_import/base_data_importer.py
+++ b/src/machine_learning/data_import/base_data_importer.py
@@ -27,15 +27,25 @@ class BaseDataImporter:
             if os.getenv("PYTHON_ENV") == "production"
             else LOCAL_AFL_DATA_SERVICE
         )
+
+        if os.getenv("PYTHON_ENV") == "production":
+            service_host = AFL_DATA_SERVICE
+            headers = {"Authorization": f'Bearer {os.getenv("GCR_TOKEN")}'}
+        else:
+            service_host = LOCAL_AFL_DATA_SERVICE
+            headers = {}
+
         service_url = urljoin(service_host, path)
 
-        response = self._make_request(service_url, params)
+        response = self._make_request(service_url, params=params, headers=headers)
 
         return self._handle_response_data(response)
 
     @staticmethod
-    def _make_request(url: str, params: Dict[str, Any] = {}) -> requests.Response:
-        response = requests.get(url, params=params)
+    def _make_request(
+        url: str, params: Dict[str, Any] = {}, headers: Dict[str, str] = {}
+    ) -> requests.Response:
+        response = requests.get(url, params=params, headers=headers)
 
         if response.status_code != 200:
             raise Exception(


### PR DESCRIPTION
I've been using security-by-obscurity for the Google Cloud Run service, but might as well add some basic authorisation similar to what I have for the serverless function. As a first step, I'm adding the token to the request, then I'll add token verification to `bird-signs`