### PR TITLE
Add misspelling of Trager to venue dicts

### DIFF
--- a/src/machine_learning/data_config.py
+++ b/src/machine_learning/data_config.py
@@ -54,6 +54,9 @@ FOOTYWIRE_VENUE_TRANSLATIONS = {
     "Marvel Stadium": "Docklands",
     "Canberra Oval": "Manuka Oval",
     "TIO Traeger Park": "Traeger Park",
+    # Correct spelling is 'Traeger', but footywire.com is spelling it 'Traegar' in its
+    # fixtures, so including both in case they eventually fix the misspelling
+    "TIO Traegar Park": "Traeger Park",
 }
 
 CITIES = {
@@ -172,6 +175,9 @@ VENUE_CITIES = {
     "Marvel Stadium": "Melbourne",
     "Canberra Oval": "Canberra",
     "TIO Traeger Park": "Alice Springs",
+    # Correct spelling is 'Traeger', but footywire.com is spelling it 'Traegar' in its
+    # fixtures, so including both in case they eventually fix the misspelling
+    "TIO Traegar Park": "Alice Springs",
 }
 
 DEFUNCT_TEAM_NAMES = ["Fitzroy", "University"]


### PR DESCRIPTION
Was getting a missing key error in my translation maps, because footywire has a misspelled version of 'TIO Trager Park' in its fixtures for the upcoming round