### PR TITLE
Fix end_date used to load data

### DIFF
--- a/src/machine_learning/api.py
+++ b/src/machine_learning/api.py
@@ -49,6 +49,7 @@ N_SEASONS_FOR_PREDICTION = 10
 # because we only need the full data set for model training and data analysis,
 # and we want to limit memory usage and speed up data processing for tipping
 PREDICTION_DATA_START_DATE = f"{date.today().year - N_SEASONS_FOR_PREDICTION}-01-01"
+END_OF_YEAR = f"{date.today().year}-12-31"
 
 
 def _clean_data_frame_for_json(data_frame: pd.DataFrame) -> List[Dict[str, Any]]:
@@ -167,7 +168,7 @@ def make_predictions(
     year_range: Tuple[int, int],
     round_number: Optional[int] = None,
     data: BaseMLData = JoinedMLData(
-        fetch_data=True, start_date=PREDICTION_DATA_START_DATE
+        fetch_data=True, start_date=PREDICTION_DATA_START_DATE, end_date=END_OF_YEAR
     ),
     ml_model_names: Optional[List[str]] = None,
     verbose=1,

--- a/src/machine_learning/data_import/footywire_data_importer.py
+++ b/src/machine_learning/data_import/footywire_data_importer.py
@@ -13,6 +13,7 @@ from .base_data_importer import BaseDataImporter
 AFL_DATA_SERVICE = "http://afl_data:8001"
 BETTING_MATCH_COLS = ["date", "venue", "round", "round_number", "season"]
 FIRST_YEAR_OF_BETTING_DATA = 2010
+END_OF_YEAR = f"{date.today().year}-12-31"
 
 # I get this warning when I run tests, but not in other contexts
 warnings.simplefilter("ignore", SystemTimeWarning)
@@ -36,7 +37,7 @@ class FootywireDataImporter(BaseDataImporter):
     def get_betting_odds(
         self,
         start_date: str = f"{FIRST_YEAR_OF_BETTING_DATA}-01-01",
-        end_date: str = str(date.today()),
+        end_date: str = END_OF_YEAR,
         fetch_data: bool = False,
     ) -> pd.DataFrame:
         """

--- a/src/machine_learning/ml_data/joined_ml_data.py
+++ b/src/machine_learning/ml_data/joined_ml_data.py
@@ -62,6 +62,8 @@ DATA_READERS: Dict[str, BaseMLData] = {
     "betting": BettingMLData(),
 }
 
+END_OF_YEAR = f"{date.today().year}-12-31"
+
 
 class JoinedMLData(BaseMLData, DataTransformerMixin):
     """Load and clean data from all data sources"""
@@ -75,7 +77,7 @@ class JoinedMLData(BaseMLData, DataTransformerMixin):
         data_transformers: List[DataFrameTransformer] = DATA_TRANSFORMERS,
         fetch_data: bool = False,
         start_date: str = "1897-01-01",
-        end_date: str = str(date.today()),
+        end_date: str = END_OF_YEAR,
     ) -> None:
         super().__init__(
             train_years=train_years,


### PR DESCRIPTION
In general, making the `end_date` equal to today works, because we don't know what future match or player data are, but for betting data, we know the odds for upcoming matches, but these were getting filtered out when making predictions. So, I made the default `end_date` equal to the end of the current year.