### PR TITLE
Fix project path reference

### DIFF
--- a/src/machine_learning/run.py
+++ b/src/machine_learning/run.py
@@ -14,6 +14,7 @@ from kedro.utils import load_obj
 import pandas as pd
 
 from machine_learning.pipeline import betting_pipeline
+from machine_learning.settings import BASE_DIR
 
 # Name of root directory containing project configuration.
 CONF_ROOT = "conf"
@@ -36,7 +37,7 @@ def __kedro_context__():
         "create_pipeline": betting_pipeline,
         "template_version": "0.14.3",
         "project_name": "Augury",
-        "project_path": Path.cwd(),
+        "project_path": BASE_DIR,
     }
 
 


### PR DESCRIPTION
Got a weird error in Google Cloud where trying to load the config files raised a `ValueError` due to the directory not existing. I'm wondering if the use of `cwd` isn't working as intended, because Google Cloud is running the code in a weird context. It works fine on local. I just set it to the consistent `BASE_DIR` to see if that fixes it.