### PR TITLE
Add a retry to fetching data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 bottle
+responses>=0.10.6,<0.11
 
 # Data packages
 numpy

--- a/src/tests/unit/data_import/test_base_data.py
+++ b/src/tests/unit/data_import/test_base_data.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+import responses
+
+from machine_learning.data_import.base_data import (
+    fetch_afl_data,
+    LOCAL_AFL_DATA_SERVICE,
+)
+
+
+FAKE_JSON = [{"number": 5, "name": "bob"}, {"number": 454, "name": "jim"}]
+
+
+class TestBaseData(TestCase):
+    def setUp(self):
+        self.add_success_response = lambda: responses.add(
+            responses.GET, f"{LOCAL_AFL_DATA_SERVICE}/data", json=FAKE_JSON, status=200
+        )
+        self.add_failure_response = lambda: responses.add(
+            responses.GET,
+            f"{LOCAL_AFL_DATA_SERVICE}/data",
+            json={"error": "bad things"},
+            status=500,
+        )
+
+    @responses.activate
+    def test_fetch_afl_data(self):
+        self.add_success_response()
+
+        res = fetch_afl_data("/data")
+        self.assertEqual(res, FAKE_JSON)
+
+        with self.subTest("when first response isn't 200"):
+            self.add_failure_response()
+            self.add_success_response()
+
+            res = fetch_afl_data("/data")
+            self.assertEqual(res, FAKE_JSON)
+
+        with self.subTest("when the retry returns a failure response"):
+            self.add_failure_response()
+            self.add_failure_response()
+
+            with self.assertRaises(Exception):
+                fetch_afl_data("/data")


### PR DESCRIPTION
I found out today that when Google Cloud Run has to start a new container, it takes a little too long and sometimes errors out, but retrying works fine. So, I added a single retry for such a situation.