### PR TITLE
Add date filter to data pipelines

### DIFF
--- a/src/machine_learning/ml_data/joined_ml_data.py
+++ b/src/machine_learning/ml_data/joined_ml_data.py
@@ -24,8 +24,8 @@ DataReaders = TypedDict(
     "DataReaders",
     {
         "player": BaseMLData,
-        "match": Callable[[], pd.DataFrame],
-        "betting": Callable[[], pd.DataFrame],
+        "match": Callable[[str, str], pd.DataFrame],
+        "betting": Callable[[str, str], pd.DataFrame],
     },
 )
 
@@ -115,11 +115,17 @@ class JoinedMLData(BaseMLData, DataTransformerMixin):
             self.data_readers["player"].end_date = self.end_date
             player_data = self.data_readers["player"].data
 
-            match_data = self.data_readers["match"]()["data"]
+            match_data = self.data_readers["match"](self.start_date, self.end_date).get(
+                "data"
+            )
 
             # Betting data dates are correct, but the times are arbitrarily set by the
             # parser, so better to leave the date definition to a different data source
-            betting_data = self.data_readers["betting"]()["data"].drop("date", axis=1)
+            betting_data = (
+                self.data_readers["betting"](self.start_date, self.end_date)
+                .get("data")
+                .drop("date", axis=1)
+            )
 
             self._data = (
                 self._compose_transformers(  # pylint: disable=E1102

--- a/src/machine_learning/nodes/match.py
+++ b/src/machine_learning/nodes/match.py
@@ -14,7 +14,7 @@ from machine_learning.data_config import (
     CITIES,
     VENUE_CITIES,
     TEAM_CITIES,
-    INDEX_COLS
+    INDEX_COLS,
 )
 from .base import _parse_dates, _translate_team_column, _validate_required_columns
 
@@ -156,11 +156,11 @@ def _map_round_type(year: int, round_number: int) -> str:
 def _round_type_column(data_frame: pd.DataFrame) -> pd.DataFrame:
     years = data_frame["year"].drop_duplicates()
 
-    if len(years) > 1:
-        raise ValueError(
-            "Fixture data should only include matches from the next round, but "
-            f"fixture data for seasons {years} were given"
-        )
+    assert len(years) == 1, (
+        "Fixture data should only include matches from the next round, but "
+        f"fixture data for seasons {list(years.values)} were given. "
+        f"The offending series is:\n{data_frame['year']}"
+    )
 
     return data_frame["round_number"].map(partial(_map_round_type, years.iloc[0]))
 
@@ -493,6 +493,7 @@ def add_win_streak(data_frame: pd.DataFrame) -> pd.DataFrame:
         win_streak=pd.Series(streak_groups, index=data_frame.index)
     )
 
+
 def add_cum_percent(data_frame: pd.DataFrame) -> pd.DataFrame:
     """Add a team's cumulative percent (cumulative score / cumulative opponents' score)"""
 
@@ -509,6 +510,7 @@ def add_cum_percent(data_frame: pd.DataFrame) -> pd.DataFrame:
     )
 
     return data_frame.assign(cum_percent=cum_score / cum_oppo_score)
+
 
 def add_ladder_position(data_frame: pd.DataFrame) -> pd.DataFrame:
     """Add a team's current ladder position (based on cumulative win points and percent)"""
@@ -548,6 +550,7 @@ def add_ladder_position(data_frame: pd.DataFrame) -> pd.DataFrame:
     )
 
     return data_frame.assign(ladder_position=ladder_position_col)
+
 
 def add_elo_pred_win(data_frame: pd.DataFrame) -> pd.DataFrame:
     """Add whether a team is predicted to win per elo ratings"""

--- a/src/machine_learning/pipeline.py
+++ b/src/machine_learning/pipeline.py
@@ -38,7 +38,7 @@ MATCH_OPPO_COLS = [
 ]
 
 
-def betting_pipeline(**_kwargs):
+def betting_pipeline(start_date: str, end_date: str, **_kwargs):
     """Kedro pipeline for loading and transforming betting data"""
 
     return Pipeline(
@@ -53,7 +53,12 @@ def betting_pipeline(**_kwargs):
                 ["betting_data_frame", "remote_betting_data_frame"],
                 "combined_betting_data",
             ),
-            node(betting.clean_data, "combined_betting_data", "clean_betting_data"),
+            node(
+                common.filter_by_date(start_date, end_date),
+                "combined_betting_data",
+                "filtered_betting_data",
+            ),
+            node(betting.clean_data, "filtered_betting_data", "clean_betting_data"),
             node(
                 common.convert_match_rows_to_teammatch_rows,
                 ["clean_betting_data"],
@@ -82,7 +87,7 @@ def betting_pipeline(**_kwargs):
     )
 
 
-def match_pipeline(**_kwargs):
+def match_pipeline(start_date: str, end_date: str, **_kwargs):
     """Kedro pipeline for loading and transforming match data"""
 
     past_match_pipeline = Pipeline(
@@ -98,8 +103,13 @@ def match_pipeline(**_kwargs):
                 "combined_past_match_data",
             ),
             node(
-                match.clean_match_data,
+                common.filter_by_date(start_date, end_date),
                 "combined_past_match_data",
+                "filtered_past_match_data",
+            ),
+            node(
+                match.clean_match_data,
+                "filtered_past_match_data",
                 "clean_past_match_data",
             ),
         ]
@@ -108,7 +118,16 @@ def match_pipeline(**_kwargs):
     upcoming_match_pipeline = Pipeline(
         [
             node(common.convert_to_data_frame, "fixture_data", "fixture_data_frame"),
-            node(match.clean_fixture_data, "fixture_data_frame", "clean_fixture_data"),
+            node(
+                common.filter_by_date(start_date, end_date),
+                "fixture_data_frame",
+                "filtered_fixture_data_frame",
+            ),
+            node(
+                match.clean_fixture_data,
+                "filtered_fixture_data_frame",
+                "clean_fixture_data",
+            ),
         ]
     )
 

--- a/src/machine_learning/run.py
+++ b/src/machine_learning/run.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable
 from warnings import warn
 import os
+from datetime import date
 
 from kedro.cli.utils import KedroCliError
 from kedro.config import ConfigLoader, MissingConfigException
@@ -96,7 +97,9 @@ def create_catalog(config: ConfigLoader, **_kwargs) -> DataCatalog:
     return catalog
 
 
-def run_betting_pipeline(runner: str = None) -> pd.DataFrame:
+def run_betting_pipeline(
+    start_date: str, end_date: str, runner: str = None
+) -> pd.DataFrame:
     # Load Catalog
     conf = get_config(project_path=BASE_DIR, env=os.getenv("PYTHON_ENV"))
     catalog = create_catalog(config=conf)
@@ -106,10 +109,12 @@ def run_betting_pipeline(runner: str = None) -> pd.DataFrame:
     runner_func = load_obj(runner, "kedro.runner") if runner else SequentialRunner
 
     # Run the runner
-    return runner_func().run(betting_pipeline(), catalog)
+    return runner_func().run(betting_pipeline(start_date, end_date), catalog)
 
 
-def run_match_pipeline(runner: str = None) -> pd.DataFrame:
+def run_match_pipeline(
+    start_date: str, end_date: str, runner: str = None
+) -> pd.DataFrame:
     # Load Catalog
     conf = get_config(project_path=str(Path.cwd()), env=os.getenv("PYTHON_ENV"))
     catalog = create_catalog(config=conf)
@@ -119,7 +124,7 @@ def run_match_pipeline(runner: str = None) -> pd.DataFrame:
     runner_func = load_obj(runner, "kedro.runner") if runner else SequentialRunner
 
     # Run the runner
-    return runner_func().run(match_pipeline(), catalog)
+    return runner_func().run(match_pipeline(start_date, end_date), catalog)
 
 
 def run_fake_estimator_pipeline(runner: str = None) -> pd.DataFrame:
@@ -159,7 +164,7 @@ def main(tags: Iterable[str] = None, env: str = None, runner: str = None):
     catalog = create_catalog(config=conf)
 
     # Load the pipeline
-    pipeline = betting_pipeline()
+    pipeline = betting_pipeline("2010-01-01", str(date.today()))
     pipeline = pipeline.only_nodes_with_tags(*tags) if tags else pipeline
     if not pipeline.nodes:
         if tags:

--- a/src/tests/fixtures/data_factories.py
+++ b/src/tests/fixtures/data_factories.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Tuple, Any, Union, cast
-from datetime import datetime
+from datetime import datetime, timedelta
 import itertools
 
 from faker import Faker
@@ -81,10 +81,19 @@ class CyclicalTeamNames:
             return next(self.cyclical_team_names)
 
 
-def _min_max_datetimes_by_year(year: int) -> Dict[str, datetime]:
+def _min_max_datetimes_by_year(
+    year: int, force_future: bool = False
+) -> Dict[str, datetime]:
+    if force_future:
+        today = datetime.now()
+        tomorrow = today + timedelta(hours=24)
+        datetime_start = datetime(year, tomorrow.month, tomorrow.day)
+    else:
+        datetime_start = datetime(year, JAN, FIRST)
+
     return {
-        "datetime_start": datetime(year, JAN, FIRST),
-        "datetime_end": datetime(year, DEC, THIRTY_FIRST),
+        "datetime_start": datetime_start,
+        "datetime_end": datetime(year, DEC, THIRTY_FIRST, 11, 59, 59),
     }
 
 
@@ -303,7 +312,10 @@ def fake_footywire_betting_data(
 
 def _fixture_data(year: int, team_names: Tuple[str, str]) -> CleanFixtureData:
     return {
-        "date": FAKE.date_time_between_dates(**_min_max_datetimes_by_year(year)),
+        "date": FAKE.date_time_between_dates(
+            **_min_max_datetimes_by_year(year, force_future=True),
+            tzinfo=MELBOURNE_TIMEZONE,
+        ),
         "season": year,
         "round": 1,
         "home_team": team_names[0],

--- a/src/tests/fixtures/data_factories.py
+++ b/src/tests/fixtures/data_factories.py
@@ -313,8 +313,7 @@ def fake_footywire_betting_data(
 def _fixture_data(year: int, team_names: Tuple[str, str]) -> CleanFixtureData:
     return {
         "date": FAKE.date_time_between_dates(
-            **_min_max_datetimes_by_year(year, force_future=True),
-            tzinfo=MELBOURNE_TIMEZONE,
+            **_min_max_datetimes_by_year(year, force_future=True)
         ),
         "season": year,
         "round": 1,

--- a/src/tests/unit/nodes/test_common.py
+++ b/src/tests/unit/nodes/test_common.py
@@ -77,6 +77,30 @@ class TestCommon(TestCase):
                 len(combined_data.columns),
             )
 
+    def test_filter_by_date(self):
+        raw_betting_data = fake_footywire_betting_data(
+            N_MATCHES_PER_SEASON, YEAR_RANGE, clean=False
+        )
+        filter_start = f"{START_YEAR + 1}-06-01"
+        filter_end = f"{START_YEAR + 1}-06-30"
+
+        filter_func = common.filter_by_date(filter_start, filter_end)
+        filtered_data_frame = filter_func(raw_betting_data)
+
+        self.assertFalse(
+            filtered_data_frame.query("date < @filter_start | date > @filter_end")
+            .any()
+            .any()
+        )
+
+        with self.subTest("with invalid date strings"):
+            with self.assertRaises(ValueError):
+                common.filter_by_date("what", "the what?")
+
+        with self.subTest("without a date column"):
+            with self.assertRaises(AssertionError):
+                filter_func(raw_betting_data.drop("date", axis=1))
+
     def test_convert_match_rows_to_teammatch_rows(self):
         # DataFrame w/ minimum valid columns
         valid_data_frame = fake_cleaned_match_data(

--- a/src/tests/unit/nodes/test_common.py
+++ b/src/tests/unit/nodes/test_common.py
@@ -13,14 +13,12 @@ from tests.fixtures.data_factories import (
 from machine_learning.nodes import common
 from machine_learning.data_config import INDEX_COLS
 
-START_DATE = "2012-01-01"
+START_DATE = "2013-01-01"
+END_DATE = "2014-12-31"
 START_YEAR = int(START_DATE[:4])
-END_DATE = "2013-12-31"
 END_YEAR = int(END_DATE[:4]) + 1
 N_MATCHES_PER_SEASON = 4
-START_YEAR = 2013
-END_YEAR = 2015
-YEAR_RANGE = (2013, 2015)
+YEAR_RANGE = (START_YEAR, END_YEAR)
 REQUIRED_OUTPUT_COLS = ["home_team", "year", "round_number"]
 
 # Need to multiply by two, because we add team & oppo_team row per match

--- a/src/tests/unit/test_api.py
+++ b/src/tests/unit/test_api.py
@@ -1,5 +1,8 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
+from datetime import date
+
+from freezegun import freeze_time
 
 from tests.fixtures.data_factories import fake_fixture_data, fake_raw_match_results_data
 from tests.fixtures.fake_estimator import FakeEstimatorData
@@ -8,7 +11,8 @@ from machine_learning import api
 from machine_learning import settings
 
 
-YEAR_RANGE = (2019, 2020)
+THIS_YEAR = date.today().year
+YEAR_RANGE = (THIS_YEAR, THIS_YEAR + 1)
 PREDICTION_ROUND = 1
 N_MATCHES = 5
 FAKE_ML_MODELS = [
@@ -16,6 +20,7 @@ FAKE_ML_MODELS = [
 ]
 
 
+@freeze_time(f"{THIS_YEAR}-06-15")
 class TestApi(TestCase):
     @patch("machine_learning.api.ML_MODELS", FAKE_ML_MODELS)
     def test_make_predictions(self):


### PR DESCRIPTION
With the introduction of the kedro pipelines, I didn't have a way to filter out older data when making predictions (which doesn't require as much data as training), which meant the data transformation steps took longer than they needed to. This adds a simple node to filter by date before doing cleaning/transformations.