### PR TITLE
Reduce prod data to 10 years

### DIFF
--- a/conf/production/catalog.yml
+++ b/conf/production/catalog.yml
@@ -5,10 +5,10 @@ betting_data:
 
 match_data:
   type: machine_learning.io.JSONGCStorageDataSet
-  filepath: match-data_1897-01-01_2018-12-31.json
+  filepath: match-data_2009-01-01_2018-12-31.json
   bucket_name: afl_data
 
 player_data:
   type: machine_learning.io.JSONGCStorageDataSet
-  filepath: player-data_1965-01-01_2018-12-31.json
+  filepath: player-data_2009-01-01_2018-12-31.json
   bucket_name: afl_data

--- a/src/machine_learning/api.py
+++ b/src/machine_learning/api.py
@@ -12,7 +12,7 @@ from machine_learning.ml_data import JoinedMLData, BaseMLData
 from machine_learning.ml_estimators import BaseMLEstimator
 from machine_learning.data_import import FitzroyDataImporter
 from machine_learning.nodes import match
-from machine_learning.settings import ML_MODELS, BASE_DIR
+from machine_learning.settings import ML_MODELS, BASE_DIR, PREDICTION_DATA_START_DATE
 
 
 PredictionData = TypedDict(
@@ -39,13 +39,6 @@ ApiResponse = TypedDict(
     "ApiResponse", {"data": Union[List[Dict[str, Any]], Dict[str, Any]]}
 )
 
-# We calculate rolling sums/means for some features that can span over 5 seasons
-# of data, so we're setting it to 10 to be on the safe side.
-N_SEASONS_FOR_PREDICTION = 10
-# We want to limit the amount of data loaded as much as possible,
-# because we only need the full data set for model training and data analysis,
-# and we want to limit memory usage and speed up data processing for tipping
-PREDICTION_DATA_START_DATE = f"{date.today().year - N_SEASONS_FOR_PREDICTION}-01-01"
 END_OF_YEAR = f"{date.today().year}-12-31"
 
 

--- a/src/machine_learning/data_import/betting_data.py
+++ b/src/machine_learning/data_import/betting_data.py
@@ -6,7 +6,7 @@ import os
 import json
 
 from machine_learning.data_import.base_data import fetch_afl_data
-from machine_learning.settings import RAW_DATA_DIR
+from machine_learning.settings import RAW_DATA_DIR, PREDICTION_DATA_START_DATE
 
 FIRST_YEAR_OF_BETTING_DATA = 2010
 END_OF_YEAR = f"{date.today().year}-12-31"
@@ -47,8 +47,25 @@ def save_betting_data(
     start_date: str = f"{FIRST_YEAR_OF_BETTING_DATA}-01-01",
     end_date: str = END_OF_YEAR,
     verbose: int = 1,
+    for_prod: bool = False,
 ) -> None:
-    """Save betting data as a *.json file with name based on date range of data"""
+    """
+    Save betting data as a *.json file with name based on date range of data
+
+    Args:
+        start_date (string: YYYY-MM-DD): Earliest date for match data returned.
+        end_date (string: YYYY-MM-DD): Latest date for match data returned.
+        verbose (int): Whether to print info statements (1 means yes, 0 means no).
+        for_prod (bool): Whether saved data set is meant for loading in production.
+            If True, this overwrites the given start_date to limit the data set
+            to the last 10 years to limit memory usage.
+
+    Returns:
+        None
+    """
+
+    if for_prod:
+        start_date = max(start_date, PREDICTION_DATA_START_DATE)
 
     data = fetch_betting_data(start_date=start_date, end_date=end_date, verbose=verbose)
     filepath = os.path.join(RAW_DATA_DIR, f"betting-data_{start_date}_{end_date}.json")

--- a/src/machine_learning/data_import/match_data.py
+++ b/src/machine_learning/data_import/match_data.py
@@ -6,7 +6,7 @@ import os
 import json
 
 from machine_learning.data_import.base_data import fetch_afl_data
-from machine_learning.settings import RAW_DATA_DIR
+from machine_learning.settings import RAW_DATA_DIR, PREDICTION_DATA_START_DATE
 
 FIRST_YEAR_OF_MATCH_DATA = 1897
 END_OF_YEAR = f"{date.today().year}-12-31"
@@ -47,8 +47,25 @@ def save_match_data(
     start_date: str = f"{FIRST_YEAR_OF_MATCH_DATA}-01-01",
     end_date: str = END_OF_LAST_YEAR,
     verbose: int = 1,
+    for_prod: bool = False,
 ) -> None:
-    """Save match data as a *.json file with name based on date range of data"""
+    """
+    Save match data as a *.json file with name based on date range of data
+
+    Args:
+        start_date (string: YYYY-MM-DD): Earliest date for match data returned.
+        end_date (string: YYYY-MM-DD): Latest date for match data returned.
+        verbose (int): Whether to print info statements (1 means yes, 0 means no).
+        for_prod (bool): Whether saved data set is meant for loading in production.
+            If True, this overwrites the given start_date to limit the data set
+            to the last 10 years to limit memory usage.
+
+    Returns:
+        None
+    """
+
+    if for_prod:
+        start_date = max(start_date, PREDICTION_DATA_START_DATE)
 
     data = fetch_match_data(start_date=start_date, end_date=end_date, verbose=verbose)
     filepath = os.path.join(RAW_DATA_DIR, f"match-data_{start_date}_{end_date}.json")

--- a/src/machine_learning/data_import/player_data.py
+++ b/src/machine_learning/data_import/player_data.py
@@ -9,7 +9,7 @@ import os
 import json
 
 from machine_learning.data_import.base_data import fetch_afl_data
-from machine_learning.settings import RAW_DATA_DIR
+from machine_learning.settings import RAW_DATA_DIR, PREDICTION_DATA_START_DATE
 
 
 # Player stats go back to 1897, but before 1965, there are only goals & behinds, which
@@ -107,6 +107,7 @@ def save_player_data(
     start_date: str = f"{EARLIEST_SEASON_WITH_EXTENSIVE_PLAYER_STATS}-01-01",
     end_date: str = END_OF_LAST_YEAR,
     verbose: int = 1,
+    for_prod: bool = False,
 ) -> None:
     """
     Save match data as a *.json file with name based on date range of data
@@ -115,10 +116,16 @@ def save_player_data(
         start_date (string: YYYY-MM-DD): Earliest date for match data returned.
         end_date (string: YYYY-MM-DD): Latest date for match data returned.
         verbose (int): Whether to print info statements (1 means yes, 0 means no).
+        for_prod (bool): Whether saved data set is meant for loading in production.
+            If True, this overwrites the given start_date to limit the data set
+            to the last 10 years to limit memory usage.
 
     Returns:
         None
     """
+
+    if for_prod:
+        start_date = max(start_date, PREDICTION_DATA_START_DATE)
 
     data = fetch_player_data(start_date=start_date, end_date=end_date, verbose=verbose)
     filepath = os.path.join(RAW_DATA_DIR, f"player-data_{start_date}_{end_date}.json")

--- a/src/machine_learning/settings.py
+++ b/src/machine_learning/settings.py
@@ -1,5 +1,5 @@
 import os
-from datetime import timezone, timedelta
+from datetime import timezone, timedelta, date
 import yaml
 
 
@@ -9,6 +9,14 @@ CASSETTE_LIBRARY_DIR = os.path.join(BASE_DIR, "src/tests/fixtures/cassettes")
 
 HOURS_FROM_UTC_TO_MELBOURNE = 11
 MELBOURNE_TIMEZONE = timezone(timedelta(hours=HOURS_FROM_UTC_TO_MELBOURNE))
+
+# We calculate rolling sums/means for some features that can span over 5 seasons
+# of data, so we're setting it to 10 to be on the safe side.
+N_SEASONS_FOR_PREDICTION = 10
+# We want to limit the amount of data loaded as much as possible,
+# because we only need the full data set for model training and data analysis,
+# and we want to limit memory usage and speed up data processing for tipping
+PREDICTION_DATA_START_DATE = f"{date.today().year - N_SEASONS_FOR_PREDICTION}-01-01"
 
 with open(os.path.join(BASE_DIR, "src/machine_learning/ml_models.yml"), "r") as file:
     ML_MODELS = yaml.safe_load(file).get("models", [])


### PR DESCRIPTION
I forgot about my 10-year limit on prediction data, so when I tried to load the entire player data set going back to 1965, my GC Function crashed from going over the memory limit. Now, I'm saving & loading data going back to 2009, which should be enough to make predictions without blowing out the memory usage.