### PR TITLE
Separate requirements into dev & prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 # Install Python dependencies
-COPY requirements.txt /app
-RUN pip3 install --upgrade pip -r requirements.txt
+COPY requirements.txt requirements.dev.txt /app/
+RUN pip3 install --upgrade pip -r requirements.dev.txt
 
 # Add the rest of the code
 COPY . /app

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,34 @@
+# Contains all dependencies necessary for doing data-sciency things locally,
+# importing the prod dependencies from requirements.txt
+
+-r requirements.txt
+
+bottle
+responses>=0.10.6,<0.11
+
+# Data packages
+scipy
+dask[complete]
+
+# Kedro packages
+ipython>=7.0.0, <8.0
+jupyter>=1.0.0, <2.0
+jupyterlab==1.1.1
+nbstripout==0.3.6
+pytest>=3.4, <6.0
+pytest-cov>=2.5, <3.0
+pytest-mock>=1.7.1,<2.0
+wheel==0.33.6
+
+# Data vis packages
+seaborn
+matplotlib
+
+# Testing/Linting
+pylint==2.3.1
+black
+faker
+mypy>=0.70
+freezegun
+factory_boy
+betamax

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,36 +1,14 @@
+# Only contains the dependencies necessary to run the serverless functions.
+# This reduces the file size deployed to Google Cloud.
+
 requests
-bottle
-responses>=0.10.6,<0.11
 google-cloud-storage==1.19.0
 
 # Data packages
 numpy
 pandas>=0.23.0,<0.26.0
 scikit-learn==0.20.1
-scipy
 xgboost==0.80
-dask[complete]
 
 # Kedro packages
 kedro==0.15.0
-ipython>=7.0.0, <8.0
-jupyter>=1.0.0, <2.0
-jupyterlab==1.1.1
-nbstripout==0.3.6
-pytest>=3.4, <6.0
-pytest-cov>=2.5, <3.0
-pytest-mock>=1.7.1,<2.0
-wheel==0.33.6
-
-# Data vis packages
-seaborn
-matplotlib
-
-# Testing/Linting
-pylint==2.3.1
-black
-faker
-mypy>=0.70
-freezegun
-factory_boy
-betamax


### PR DESCRIPTION
I've been getting timeout errors when trying to deploy
Google Cloud functions. I'm hoping that reducing the number
of dependencies to the bare minimum necessary to run the
functions will speed up deployments.