### PR TITLE
Add mypy back to prod requirements

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -28,7 +28,6 @@ matplotlib
 pylint==2.3.1
 black
 faker
-mypy>=0.70
 freezegun
 factory_boy
 betamax

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ xgboost==0.80
 
 # Kedro packages
 kedro==0.15.0
+
+# Testing/Linting
+mypy>=0.70 # Need mypy due to references to mypy_extensions in production code


### PR DESCRIPTION
Because we use `mypy_extensions` to define types in code that runs in prod.