### PR TITLE
Make sure Geelong is home team for rnd 24, 2019

### DIFF
--- a/src/machine_learning/api.py
+++ b/src/machine_learning/api.py
@@ -168,6 +168,8 @@ def make_predictions(
     verbose=1,
     train=False,
 ) -> ApiResponse:
+    data.round_number = round_number
+
     partial_make_predictions_by_year = partial(
         _make_predictions_by_year,
         data,

--- a/src/machine_learning/nodes/match.py
+++ b/src/machine_learning/nodes/match.py
@@ -84,7 +84,7 @@ def clean_match_data(match_data: pd.DataFrame) -> pd.DataFrame:
         Cleanish pandas.DataFrame
     """
     if any(match_data):
-        return (
+        clean_data = (
             match_data.rename(columns=MATCH_COL_TRANSLATIONS)
             .astype({"year": int, "round_number": int})
             .pipe(
@@ -101,6 +101,31 @@ def clean_match_data(match_data: pd.DataFrame) -> pd.DataFrame:
             .drop("round", axis=1)
             .sort_values("date")
         )
+
+        # AFLTables has some incorrect home/away team designations for finals 2019
+        round_24_2019 = (clean_data["year"] == 2019) & (
+            clean_data["round_number"] == 24
+        )
+
+        clean_data.loc[
+            round_24_2019 & (clean_data["home_team"] == "Collingwood"),
+            ["home_team", "away_team"],
+        ] = ["Geelong", "Collingwood"]
+        clean_data.loc[
+            round_24_2019 & (clean_data["home_team"] == "Richmond"),
+            ["home_team", "away_team"],
+        ] = ["Brisbane", "Richmond"]
+
+        round_25_2019 = (clean_data["year"] == 2019) & (
+            clean_data["round_number"] == 25
+        )
+
+        clean_data.loc[
+            round_25_2019 & (clean_data["home_team"] == "GWS"),
+            ["home_team", "away_team"],
+        ] = ["Brisbane", "GWS"]
+
+        return clean_data
 
     return pd.DataFrame()
 


### PR DESCRIPTION
The Footywire fixture data error was fixed, but now AFLTables is saying that Collingwood was the home team against Geelong, when, officially at least, they were the away team. At the MCG. Because reasons.