### PR TITLE
Fix mixed up date columns

### DIFF
--- a/src/machine_learning/data_config.py
+++ b/src/machine_learning/data_config.py
@@ -174,7 +174,7 @@ CITIES: Dict[str, Dict[str, Union[str, float]]] = {
         "state": "NSW",
         "lat": -36.0737,
         "long": 146.9135,
-        "timezone": "Australia/Sidney",
+        "timezone": "Australia/Sydney",
     },
     "Townsville": {
         "state": "QLD",

--- a/src/machine_learning/nodes/player.py
+++ b/src/machine_learning/nodes/player.py
@@ -145,7 +145,7 @@ def clean_player_data(
                 duplicate_subset=["year", "round_number", "player_id"]
             )
         )
-        .drop("venue", axis=1)
+        .drop(["venue"], axis=1)
         # brownlow_votes aren't known until the end of the season
         .fillna({"brownlow_votes": 0})
         # Joining on date/venue leaves two duplicates played at M.C.G.


### PR DESCRIPTION
Recent changes to timezones & the function `_parse_dates` resulted in date columns getting mixed up and no longer matching the index order of the relevant data frame. Turns out I wanted to use `apply` rather than iterating over rows, which doesn't guarantee the same order.