### PR TITLE
Add team/round/year validation

### DIFF
--- a/src/machine_learning/nodes/base.py
+++ b/src/machine_learning/nodes/base.py
@@ -52,6 +52,24 @@ def _validate_required_columns(
     )
 
 
+def _validate_unique_team_index_columns(data_frame: pd.DataFrame):
+    duplicate_home_team_indices = data_frame[
+        ["home_team", "year", "round_number"]
+    ].duplicated(keep=False)
+    assert not duplicate_home_team_indices.any().any(), (
+        "Cleaning player data resulted in rows with duplicate indices:\n"
+        f"{data_frame[duplicate_home_team_indices]}"
+    )
+
+    duplicate_away_indices = data_frame[
+        ["away_team", "year", "round_number"]
+    ].duplicated(keep=False)
+    assert not duplicate_away_indices.any().any(), (
+        "Cleaning player data resulted in rows with duplicate indices:\n"
+        f"{data_frame[duplicate_away_indices]}"
+    )
+
+
 def _filter_out_dodgy_data(duplicate_subset=None) -> Callable:
     return lambda df: (
         df.sort_values("date", ascending=True)

--- a/src/machine_learning/nodes/betting.py
+++ b/src/machine_learning/nodes/betting.py
@@ -4,7 +4,12 @@ from typing import List
 
 import pandas as pd
 
-from .base import _parse_dates, _translate_team_column, _validate_required_columns
+from .base import (
+    _parse_dates,
+    _translate_team_column,
+    _validate_required_columns,
+    _validate_unique_team_index_columns,
+)
 
 
 def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
@@ -18,7 +23,7 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
     Returns:
         pandas.DataFrame
     """
-    return (
+    clean_betting_data = (
         betting_data.rename(columns={"season": "year"})
         .drop(
             [
@@ -39,6 +44,10 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
         )
         .drop("round", axis=1)
     )
+
+    _validate_unique_team_index_columns(clean_betting_data)
+
+    return clean_betting_data
 
 
 def add_betting_pred_win(data_frame: pd.DataFrame) -> pd.DataFrame:

--- a/src/machine_learning/nodes/match.py
+++ b/src/machine_learning/nodes/match.py
@@ -22,6 +22,7 @@ from .base import (
     _validate_required_columns,
     _filter_out_dodgy_data,
     _convert_id_to_string,
+    _validate_unique_team_index_columns,
 )
 
 
@@ -124,6 +125,8 @@ def clean_match_data(match_data: pd.DataFrame) -> pd.DataFrame:
             ["home_team", "away_team"],
         ] = ["Brisbane", "GWS"]
 
+        _validate_unique_team_index_columns(clean_data)
+
         return clean_data
 
     return pd.DataFrame()
@@ -207,6 +210,8 @@ def clean_fixture_data(fixture_data: pd.DataFrame) -> pd.DataFrame:
         )
         .fillna(0)
     )
+
+    _validate_unique_team_index_columns(fixture_data_frame)
 
     return fixture_data_frame
 


### PR DESCRIPTION
With the recent data bug, I realised I should be validating index values earlier in the pipeline to reduce the amount of mucking about required to find the source.