### PR TITLE
Update betting import

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# We use loadfile to group tests by file to avoid IO errors
+docker-compose run --rm data_science kedro test -n auto --dist=loadfile $*

--- a/src/machine_learning/ml_data.py
+++ b/src/machine_learning/ml_data.py
@@ -36,7 +36,7 @@ class MLData:
         **pipeline_kwargs,
     ) -> None:
         self.pipeline = pipeline
-        self.data_set = data_set
+        self._data_set = data_set
         self._train_years = train_years
         self._test_years = test_years
         self.start_date = start_date
@@ -74,7 +74,7 @@ class MLData:
 
         return X_train, y_train
 
-    def test_data(self, test_round=None) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def test_data(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """Filter data by year to produce test data"""
 
         if len(self.data.index.names) != 3:
@@ -85,7 +85,7 @@ class MLData:
             )
 
         data_test = self.data.loc[
-            (slice(None), slice(*self.test_years), slice(test_round, test_round)), :
+            (slice(None), slice(*self.test_years), slice(None)), :
         ]
         X_test = self.__X(data_test)
         y_test = self.__y(data_test)
@@ -111,6 +111,19 @@ class MLData:
     @test_years.setter
     def test_years(self, years: YearPair) -> None:
         self._test_years = years
+
+    @property
+    def data_set(self) -> str:
+        """Name of the associated kedro data set"""
+
+        return self._data_set
+
+    @data_set.setter
+    def data_set(self, name: str) -> None:
+        if self._data_set != name:
+            self._data = None
+
+        self._data_set = name
 
     def __load_data(self):
         if self.update_data or not self.__data_context.catalog.exists(self.data_set):

--- a/src/machine_learning/ml_models.yml
+++ b/src/machine_learning/ml_models.yml
@@ -1,7 +1,10 @@
 models:
   - name: tipresias_2019_model
+    data_set: legacy_model_data
     trained_to: 2018
   - name: benchmark_estimator_model
+    data_set: legacy_model_data
     trained_to: 2018
   - name: stacking_estimator
+    data_set: model_data
     trained_to: 2016

--- a/src/machine_learning/nodes/betting.py
+++ b/src/machine_learning/nodes/betting.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from .base import (
     _parse_dates,
+    _translate_team_column,
     _validate_required_columns,
     _validate_unique_team_index_columns,
     _filter_out_dodgy_data,
@@ -42,7 +43,11 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
             ],
             axis=1,
         )
-        .assign(date=_parse_dates)
+        .assign(
+            home_team=_translate_team_column("home_team"),
+            away_team=_translate_team_column("away_team"),
+            date=_parse_dates,
+        )
     )
 
     _validate_unique_team_index_columns(clean_betting_data)

--- a/src/machine_learning/nodes/betting.py
+++ b/src/machine_learning/nodes/betting.py
@@ -6,7 +6,6 @@ import pandas as pd
 
 from .base import (
     _parse_dates,
-    _translate_team_column,
     _validate_required_columns,
     _validate_unique_team_index_columns,
     _filter_out_dodgy_data,
@@ -43,11 +42,7 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
             ],
             axis=1,
         )
-        .assign(
-            home_team=_translate_team_column("home_team"),
-            away_team=_translate_team_column("away_team"),
-            date=_parse_dates,
-        )
+        .assign(date=_parse_dates)
     )
 
     _validate_unique_team_index_columns(clean_betting_data)

--- a/src/machine_learning/nodes/betting.py
+++ b/src/machine_learning/nodes/betting.py
@@ -25,7 +25,7 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
         pandas.DataFrame
     """
     clean_betting_data = (
-        betting_data.rename(columns={"season": "year"})
+        betting_data.rename(columns={"season": "year", "round": "round_number"})
         .pipe(
             _filter_out_dodgy_data(
                 duplicate_subset=["year", "round_number", "home_team", "away_team"]
@@ -48,7 +48,6 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
             away_team=_translate_team_column("away_team"),
             date=_parse_dates,
         )
-        .drop("round", axis=1)
     )
 
     _validate_unique_team_index_columns(clean_betting_data)

--- a/src/tests/unit/test_api.py
+++ b/src/tests/unit/test_api.py
@@ -15,7 +15,7 @@ THIS_YEAR = date.today().year
 YEAR_RANGE = (2018, 2019)
 PREDICTION_ROUND = 1
 N_MATCHES = 5
-FAKE_ML_MODELS = [{"name": "fake_estimator_model"}]
+FAKE_ML_MODELS = [{"name": "fake_estimator_model", "data_set": "fake_data"}]
 
 
 class TestApi(TestCase):


### PR DESCRIPTION
Recent changes to `fitzRoy` permitted changes to simplify `bird-signs`, which required small changes to how we clean betting data. While testing the changes, I ran into a few bugs with the end-to-end `api.make_predictions`, so fixed those as well.