### PR TITLE
Downgrade tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ xgboost==0.90
 mlxtend==0.17.0
 statsmodels==0.10.2
 scipy==1.4.1
-tensorflow==2.1.0
+tensorflow==2.0.0
 
 # Kedro packages
 kedro==0.15.5


### PR DESCRIPTION
Google Cloud Functions are using an oldish version of pip,
which can't install the latest tensorflow. According to the error
message, it appears they have access to 2.0.0