### PR TITLE
Downgrade tensorflow version again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,10 @@ xgboost==0.90
 mlxtend==0.17.0
 statsmodels==0.10.2
 scipy==1.4.1
-tensorflow==2.0.0
+# Can't install latest version as of 21-1-2020, because Google Cloud Platform
+# uses an older version of pip that doesn't recognise versions 2+ except for
+# some weird pre-release versions of 2.0.0
+tensorflow==1.14.0
 
 # Kedro packages
 kedro==0.15.5

--- a/src/tests/fixtures/data_factories.py
+++ b/src/tests/fixtures/data_factories.py
@@ -124,16 +124,21 @@ class CyclicalTeamNames:
 def _min_max_datetimes_by_year(
     year: int, force_future: bool = False
 ) -> Dict[str, datetime]:
+    # About as early as matches ever start
+    MIN_MATCH_HOUR = 12
+    # About as late as matches ever start
+    MAX_MATCH_HOUR = 20
+
     if force_future:
         today = datetime.now()
         tomorrow = today + timedelta(hours=24)
-        datetime_start = datetime(year, tomorrow.month, tomorrow.day)
+        datetime_start = datetime(year, tomorrow.month, tomorrow.day, MIN_MATCH_HOUR)
     else:
-        datetime_start = datetime(year, JAN, FIRST)
+        datetime_start = datetime(year, JAN, FIRST, MIN_MATCH_HOUR)
 
     return {
         "datetime_start": datetime_start,
-        "datetime_end": datetime(year, DEC, THIRTY_FIRST, 11, 59, 59),
+        "datetime_end": datetime(year, DEC, THIRTY_FIRST, MAX_MATCH_HOUR),
     }
 
 


### PR DESCRIPTION
`1.14.0` is the highest non-pre-release version available in Google Cloud Functions per the error message I keep getting when trying to deploy. Since I'm not doing anything too fancy, I imagine I don't really need anything introduced in `2.x`.