### PR TITLE
Update data sets

### DIFF
--- a/conf/development/catalog.yml
+++ b/conf/development/catalog.yml
@@ -1,51 +1,51 @@
 # Raw data
 betting_data:
   type: JSONLocalDataSet
-  filepath: /app/data/01_raw/betting-data_2010-01-01_2018-12-31.json
+  filepath: /app/data/01_raw/betting-data_2010-01-01_2019-12-31.json
   save_args:
     indent: 2
 match_data:
   type: JSONLocalDataSet
-  filepath: /app/data/01_raw/match-data_1897-01-01_2018-12-31.json
+  filepath: /app/data/01_raw/match-data_1897-01-01_2019-12-31.json
   save_args:
     indent: 2
 player_data:
   type: JSONLocalDataSet
-  filepath: /app/data/01_raw/player-data_1965-01-01_2018-12-31.json
+  filepath: /app/data/01_raw/player-data_1965-01-01_2019-12-31.json
   save_args:
     indent: 2
 
 # Intermediate data
 final_betting_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/betting-data_2010-01-01_2018-12-31.json
+  filepath: /app/data/02_intermediate/betting-data_2010-01-01_2019-12-31.json
   save_args:
     indent: 2
 final_match_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/match-data_1897-01-01_2018-12-31.json
+  filepath: /app/data/02_intermediate/match-data_1897-01-01_2019-12-31.json
   save_args:
     indent: 2
 final_legacy_match_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/legacy-match-data_1897-01-01_2018-12-31.json
+  filepath: /app/data/02_intermediate/legacy-match-data_1897-01-01_2019-12-31.json
   save_args:
     indent: 2
 final_player_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/player-data_1965-01-01_2018-12-31.json
+  filepath: /app/data/02_intermediate/player-data_1965-01-01_2019-12-31.json
   save_args:
     indent: 2
 
 # Final data
 legacy_model_data:
   type: JSONLocalDataSet
-  filepath: /app/data/05_model_input/legacy-model-data_1897-01-01_2019-12-31.json
+  filepath: /app/data/05_model_input/legacy-model-data_1897-01-01_2020-12-31.json
   save_args:
     indent: 2
 model_data:
   type: JSONLocalDataSet
-  filepath: /app/data/05_model_input/model-data_1897-01-01_2019-12-31.json
+  filepath: /app/data/05_model_input/model-data_1897-01-01_2020-12-31.json
   save_args:
     indent: 2
 

--- a/scripts/generate_data_sets.sh
+++ b/scripts/generate_data_sets.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-mkdir -p "${PWD}/data/01_raw"
+DATA_DIR="${PWD}/data"
+mkdir -p "${DATA_DIR}/01_raw" "${DATA_DIR}/02_intermediate" "${DATA_DIR}/05_model_input"
 
 DATA_IMPORT_DIR="${PWD}/src/augury/data_import"
 python3 "${DATA_IMPORT_DIR}/betting_data.py"
 python3 "${DATA_IMPORT_DIR}/match_data.py"
 python3 "${DATA_IMPORT_DIR}/player_data.py"
+
+kedro run --pipeline legacy -e development
+kedro run --pipeline full -e development


### PR DESCRIPTION
Old data sets were causing weird errors in `tipresias`, because the data set names were based off of last year's (2019) limits, so I updated the names and the script to include all data sets, including ones generated mid-pipeline.