### PR TITLE
Correct confidence model's prediction type

### DIFF
--- a/src/augury/ml_models.yml
+++ b/src/augury/ml_models.yml
@@ -16,6 +16,6 @@ models:
     data_set: model_data
     trained_to: 2016
   - name: confidence_estimator
-    prediction_type: margin
+    prediction_type: confidence
     data_set: model_data
     trained_to: 2016


### PR DESCRIPTION
Bad copy-pasta: the `prediction_type` of `confidence_estimator` should, obviously, be `confidence`