### PR TITLE
Return margin and probability predictions as separate fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 requests
 google-cloud-storage==1.25.0
 joblib
+simplejson
 
 # Data packages
 numpy==1.16.4

--- a/src/augury/api.py
+++ b/src/augury/api.py
@@ -15,24 +15,6 @@ from augury.types import YearRange
 from augury.settings import ML_MODELS, PREDICTION_DATA_START_DATE, BASE_DIR
 
 
-PredictionData = TypedDict(
-    "PredictionData",
-    {
-        "team": str,
-        "year": int,
-        "round_number": int,
-        "at_home": int,
-        "oppo_team": str,
-        "ml_model": str,
-        "predicted_margin": float,
-    },
-)
-
-DataConfig = TypedDict(
-    "DataConfig",
-    {"team_names": List[str], "defunct_team_names": List[str], "venues": List[str]},
-)
-
 ApiResponse = TypedDict(
     "ApiResponse", {"data": Union[List[Dict[str, Any]], Dict[str, Any]]}
 )

--- a/src/augury/api.py
+++ b/src/augury/api.py
@@ -6,6 +6,7 @@ from datetime import date
 import pandas as pd
 from mypy_extensions import TypedDict
 from kedro.context import load_context
+import simplejson
 
 from augury.data_import import match_data
 from augury.nodes import match
@@ -40,13 +41,12 @@ END_OF_YEAR = f"{date.today().year}-12-31"
 
 
 def _clean_data_frame_for_json(data_frame: pd.DataFrame) -> List[Dict[str, Any]]:
-    clean_data_frame = (
-        data_frame.astype({"date": str})
-        if "date" in data_frame.columns
-        else data_frame.copy()
+    # I don't feel great about this, but there isn't a good way of converting np.nan
+    # to null for JSON. Since GCF expects dicts that it converts to JSON for us,
+    # we call dumps then loads to avoid nested stringified weirdness.
+    return simplejson.loads(
+        simplejson.dumps(data_frame.to_dict("records"), ignore_nan=True, default=str)
     )
-
-    return clean_data_frame.to_dict("records")
 
 
 def _api_response(data: Union[pd.DataFrame, Dict[str, Any]]) -> ApiResponse:

--- a/src/augury/ml_models.yml
+++ b/src/augury/ml_models.yml
@@ -16,6 +16,6 @@ models:
     data_set: model_data
     trained_to: 2016
   - name: confidence_estimator
-    prediction_type: confidence
+    prediction_type: win_probability
     data_set: model_data
     trained_to: 2016

--- a/src/augury/predictions.py
+++ b/src/augury/predictions.py
@@ -57,7 +57,7 @@ class Predictor:
             for year in range(*self.year_range)
         ]
 
-        return pd.concat(list(itertools.chain.from_iterable(predictions)))
+        return pd.concat(list(itertools.chain.from_iterable(predictions)), sort=False)
 
     def _make_predictions_by_year(self, ml_models, year: int) -> List[pd.DataFrame]:
         return [self._make_model_predictions(year, ml_model) for ml_model in ml_models]
@@ -83,12 +83,11 @@ class Predictor:
             year,
             slice(self.round_number, self.round_number),
         )
+        prediction_type = ml_model["prediction_type"]
 
         model_predictions = (
             X_test.assign(
-                predicted_margin=y_pred,
-                ml_model=ml_model["name"],
-                prediction_type=ml_model["prediction_type"],
+                **{f"predicted_{prediction_type}": y_pred}, ml_model=ml_model["name"]
             )
             .set_index("ml_model", append=True, drop=False)
             .loc[
@@ -100,8 +99,7 @@ class Predictor:
                     "oppo_team",
                     "at_home",
                     "ml_model",
-                    "predicted_margin",
-                    "prediction_type",
+                    f"predicted_{prediction_type}",
                 ],
             ]
         )

--- a/src/tests/fixtures/data_factories.py
+++ b/src/tests/fixtures/data_factories.py
@@ -246,7 +246,10 @@ def fake_cleaned_match_data(
     return (
         data_frame.assign(
             date=lambda df: pd.to_datetime(df["date"]).dt.tz_localize(
-                MELBOURNE_TIMEZONE
+                # Sometimes get ambiguous datetime errors due to 2:00 am to 3:00 am
+                # potentially being daylight-savings time or standard time
+                # on transitional days, so we just infer, because we don't really care.
+                MELBOURNE_TIMEZONE, ambiguous='infer',
             )
         )
         .set_index(INDEX_COLS, drop=False)

--- a/src/tests/unit/test_api.py
+++ b/src/tests/unit/test_api.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 from datetime import date
 from typing import List
+import json
 
 from tests.fixtures.data_factories import fake_fixture_data, fake_raw_match_results_data
 from augury.data_import import match_data
@@ -33,6 +34,10 @@ class TestApi(TestCase):
     def test_make_predictions(self, mock_make_predictions):
         mock_make_predictions.return_value = fake_fixture_data(N_MATCHES, YEAR_RANGE)
         response = api.make_predictions(YEAR_RANGE, ml_model_names=["fake_estimator"])
+
+        # Check that it serializes to valid JSON due to potential issues
+        # with pd.Timestamp and np.nan values
+        self.assertEqual(response, json.loads(json.dumps(response)))
 
         data = response["data"]
 

--- a/src/tests/unit/test_predictions.py
+++ b/src/tests/unit/test_predictions.py
@@ -16,7 +16,12 @@ from augury.settings import BASE_DIR
 YEAR_RANGE = (2018, 2019)
 PREDICTION_ROUND = 1
 FAKE_ML_MODELS = [
-    {"name": "fake_estimator", "data_set": "fake_data", "prediction_type": "margin"}
+    {"name": "fake_estimator", "data_set": "fake_data", "prediction_type": "margin"},
+    {
+        "name": "fake_estimator",
+        "data_set": "fake_data",
+        "prediction_type": "win_probability",
+    },
 ]
 
 
@@ -42,8 +47,7 @@ class TestPredictor(TestCase, KedroContextMixin):
         with freeze_time(f"{self.max_year}-06-15"):
             model_predictions = self.predictor.make_predictions(FAKE_ML_MODELS)
 
-        self.assertEqual(len(model_predictions), len(self.prediction_matches))
-
+        self.assertEqual(len(model_predictions), len(self.prediction_matches) * 2)
         self.assertEqual(
             set(model_predictions.columns),
             set(
@@ -55,7 +59,7 @@ class TestPredictor(TestCase, KedroContextMixin):
                     "oppo_team",
                     "ml_model",
                     "predicted_margin",
-                    "prediction_type",
+                    "predicted_win_probability",
                 ]
             ),
         )


### PR DESCRIPTION
To make it easier for the main app to save different types of predictions, we're separating them on this side of the API.