### PR TITLE
Fix handling of blank query params

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,13 +32,11 @@ def predictions():
     year_range = tuple([int(year) for year in year_range_param.split("-")])
 
     round_number = request.query.round_number
-    round_number = int(round_number) if round_number is not None else None
+    round_number = int(round_number) if round_number not in [None, ""] else None
 
     ml_models_param = request.query.ml_models
     ml_models_param = (
-        ml_models_param.split(",")
-        if ml_models_param is not None and ml_models_param != ""
-        else None
+        ml_models_param.split(",") if ml_models_param not in [None, ""] else None
     )
 
     return api.make_predictions(

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,7 +3,7 @@
 
 -r requirements.txt
 
-bottle
+bottle==0.12.18
 responses>=0.10.6,<0.11
 
 # Data packages


### PR DESCRIPTION
I'm guessing a recent update to bottle changed defaulting to None
to defaulting to blank string. Fixing the version to prevent this
sneaking up on me in the future.