### PR TITLE
Fix bits_objective calculation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - PYTHON_ENV=development
       - GOOGLE_APPLICATION_CREDENTIALS=.gcloud/keyfile.json
+      - PYTHONPATH=./src
     command: python3 app.py
   afl_data:
     image: cfranklin11/tipresias_afl_data:latest

--- a/src/augury/ml_models.yml
+++ b/src/augury/ml_models.yml
@@ -5,17 +5,21 @@
 models:
   - name: tipresias_2019
     prediction_type: margin
-    data_set: legacy_model_data
     trained_to: 2016
+    data_set: legacy_model_data
+    label_col: margin
   - name: benchmark_estimator
     prediction_type: margin
-    data_set: legacy_model_data
     trained_to: 2016
+    data_set: legacy_model_data
+    label_col: margin
   - name: tipresias_2020
     prediction_type: margin
-    data_set: model_data
     trained_to: 2016
+    data_set: model_data
+    label_col: margin
   - name: confidence_estimator
     prediction_type: win_probability
-    data_set: model_data
     trained_to: 2016
+    data_set: model_data
+    label_col: result

--- a/src/augury/predictions.py
+++ b/src/augury/predictions.py
@@ -78,6 +78,7 @@ class Predictor:
 
         loaded_model = self.context.catalog.load(ml_model["name"])
         self._data.data_set = ml_model["data_set"]
+        self._data.label_col = ml_model["label_col"]
 
         trained_model = self._train_model(loaded_model) if self.train else loaded_model
         X_test, _ = self._data.test_data

--- a/src/augury/sklearn/metrics.py
+++ b/src/augury/sklearn/metrics.py
@@ -216,7 +216,7 @@ def bits_objective(y_true, y_pred) -> Tuple[np.array, np.array]:
     # and give a team a 100% chance of winning, which results
     # in some divide-by-zero errors, so we make the maximum just a little less than 1.
     MAX_PROBA = 1 - MIN_LOG_VAL
-    normalized_y_pred = np.maximum(y_pred, np.full_like(y_pred, MAX_PROBA))
+    normalized_y_pred = np.minimum(y_pred, np.full_like(y_pred, MAX_PROBA))
 
     return (
         _bits_gradient(y_true_matrix, normalized_y_pred).flatten(),

--- a/src/augury/sklearn/metrics.py
+++ b/src/augury/sklearn/metrics.py
@@ -215,8 +215,15 @@ def bits_objective(y_true, y_pred) -> Tuple[np.array, np.array]:
     # Sometimes during training, the confidence estimator will get frisky
     # and give a team a 100% chance of winning, which results
     # in some divide-by-zero errors, so we make the maximum just a little less than 1.
-    MAX_PROBA = 1 - MIN_LOG_VAL
+    # We use the exponent -7, because any smaller and numpy rounds the values to 1.
+    MAX_PROBA = 1 - (1 * 10 ** -7)
     normalized_y_pred = np.minimum(y_pred, np.full_like(y_pred, MAX_PROBA))
+
+    assert not np.any(normalized_y_pred[normalized_y_pred == 1]), (
+        "No predictions can be exactly 1, because they eventually produce "
+        "divide-by-one errors due to how the gradient and hessian are calculated "
+        "for the bits metric."
+    )
 
     return (
         _bits_gradient(y_true_matrix, normalized_y_pred).flatten(),

--- a/src/tests/unit/test_predictions.py
+++ b/src/tests/unit/test_predictions.py
@@ -16,11 +16,17 @@ from augury.settings import BASE_DIR
 YEAR_RANGE = (2018, 2019)
 PREDICTION_ROUND = 1
 FAKE_ML_MODELS = [
-    {"name": "fake_estimator", "data_set": "fake_data", "prediction_type": "margin"},
+    {
+        "name": "fake_estimator",
+        "data_set": "fake_data",
+        "prediction_type": "margin",
+        "label_col": "margin",
+    },
     {
         "name": "fake_estimator",
         "data_set": "fake_data",
         "prediction_type": "win_probability",
+        "label_col": "result",
     },
 ]
 
@@ -69,7 +75,7 @@ class TestPredictor(TestCase, KedroContextMixin):
             prediction_year = prediction_years.iloc[0]
             self.assertEqual(prediction_year, [YEAR_RANGE[0]])
 
-            with self.subTest('when only one ml_model is given'):
+            with self.subTest("when only one ml_model is given"):
                 model_predictions = self.predictor.make_predictions(FAKE_ML_MODELS[1:])
 
                 self.assertEqual(len(model_predictions), len(self.prediction_matches))


### PR DESCRIPTION
I was getting `NaN`ful predictions from the `ConfidenceEstimator`, and it turns out that I had made some mistakes in implementing preventative measures for avoiding divide-by-zero errors in the `bits_objective`, which the estimator uses during training. This is also a flaky bug, because the estimator doesn't always include predictions of 1 during training, but it always does when the random seed is set to 42 (hooray for reproducibility?).

I also noticed that the `Predictor` wouldn't work well for the `ConfidenceEstimator`, because the kwargs passed to `MLData` are incorrect. I should figure out a better way to manage model config issues like this, but it's okay enough for now.