### PR TITLE
Fix running functions in prod

### DIFF
--- a/conf/production/catalog.yml
+++ b/conf/production/catalog.yml
@@ -1,15 +1,15 @@
 # Raw data
 betting_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: betting-data_2010-01-01_2018-12-31.json
+  filepath: betting-data_2010-01-01_2019-12-31.json
   bucket_name: afl_data
 match_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: match-data_2009-01-01_2018-12-31.json
+  filepath: match-data_2009-01-01_2019-12-31.json
   bucket_name: afl_data
 player_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: player-data_2009-01-01_2018-12-31.json
+  filepath: player-data_2009-01-01_2019-12-31.json
   bucket_name: afl_data
 
 # Final data

--- a/conf/production/catalog.yml
+++ b/conf/production/catalog.yml
@@ -27,15 +27,19 @@ tipresias_2019:
   type: augury.io.PickleGCStorageDataSet
   filepath: tipresias_2019.pkl
   bucket_name: afl_data
+  project_dir: /
 benchmark_estimator:
   type: augury.io.PickleGCStorageDataSet
   filepath: benchmark_estimator.pkl
   bucket_name: afl_data
+  project_dir: /
 tipresias_2020:
   type: augury.io.PickleGCStorageDataSet
   filepath: tipresias_2020.pkl
   bucket_name: afl_data
+  project_dir: /
 confidence_estimator:
   type: augury.io.PickleGCStorageDataSet
   filepath: confidence_estimator.pkl
   bucket_name: afl_data
+  project_dir: /

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,6 +32,7 @@ package:
     - package-lock.json
     - package.json
     - requirements.txt
+    - .kedro.yml
 
 functions:
   predictions:

--- a/src/augury/pipelines/pipelines.py
+++ b/src/augury/pipelines/pipelines.py
@@ -4,7 +4,6 @@ from typing import Dict
 
 from kedro.pipeline import Pipeline
 
-from tests.fixtures.fake_estimator import create_fake_pipeline
 from augury.nodes import feature_calculation
 from augury.settings import CATEGORY_COLS
 from .player_pipeline import create_player_pipeline
@@ -52,5 +51,4 @@ def create_pipelines(start_date, end_date, **_kwargs) -> Dict[str, Pipeline]:
             final_data_set="legacy_model_data",
             category_cols=CATEGORY_COLS,
         ),
-        "fake": create_fake_pipeline(),
     }

--- a/src/tests/unit/test_model_tracking.py
+++ b/src/tests/unit/test_model_tracking.py
@@ -6,7 +6,11 @@ from unittest.mock import patch, MagicMock
 import re
 
 from tests.helpers import KedroContextMixin
-from tests.fixtures.fake_estimator import FakeEstimatorData, FakeEstimator
+from tests.fixtures.fake_estimator import (
+    FakeEstimatorData,
+    FakeEstimator,
+    create_fake_pipeline,
+)
 from augury.model_tracking import (
     present_model_params,
     IRRELEVANT_PARAM_REGEX,
@@ -44,6 +48,7 @@ class TestModelTracking(TestCase, KedroContextMixin):
             all([isinstance(value, BASE_PARAM_VALUE_TYPES) for value in param_values])
         )
 
+    @patch("augury.run.create_pipelines", {"fake": create_fake_pipeline()})
     @patch("augury.model_tracking.mlflow")
     def test_start_run(self, mock_mlflow):
         max_of_year_range = VALIDATION_YEAR_RANGE[1]

--- a/src/tests/unit/test_predictions.py
+++ b/src/tests/unit/test_predictions.py
@@ -2,14 +2,14 @@
 # pylint: disable=missing-class-docstring
 
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import os
 
 import joblib
 from freezegun import freeze_time
 
 from tests.helpers import KedroContextMixin
-from tests.fixtures.fake_estimator import FakeEstimatorData
+from tests.fixtures.fake_estimator import FakeEstimatorData, create_fake_pipeline
 from augury.predictions import Predictor
 from augury.settings import BASE_DIR
 
@@ -49,6 +49,7 @@ class TestPredictor(TestCase, KedroContextMixin):
 
         self.predictor._data = fake_data  # pylint: disable=protected-access
 
+    @patch("augury.run.create_pipelines", {"fake": create_fake_pipeline()})
     def test_make_predictions(self):
         with freeze_time(f"{self.max_year}-06-15"):
             model_predictions = self.predictor.make_predictions(FAKE_ML_MODELS)

--- a/src/tests/unit/test_sklearn.py
+++ b/src/tests/unit/test_sklearn.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 
 from unittest import TestCase
+from unittest.mock import patch
 import os
 import warnings
 
@@ -13,7 +14,7 @@ import pytest
 
 from tests.helpers import KedroContextMixin
 from tests.fixtures.data_factories import fake_cleaned_match_data
-from tests.fixtures.fake_estimator import FakeEstimatorData
+from tests.fixtures.fake_estimator import FakeEstimatorData, create_fake_pipeline
 from augury.sklearn.models import AveragingRegressor, EloRegressor, KerasClassifier
 from augury.sklearn.preprocessing import (
     CorrelationSelector,
@@ -235,6 +236,7 @@ class TestDataFrameConverter(TestCase):
 
 
 class TestKerasClassifier(TestCase):
+    @patch("augury.run.create_pipelines", {"fake": create_fake_pipeline()})
     def setUp(self):
         data = FakeEstimatorData()
         _X_train, _y_train = data.train_data


### PR DESCRIPTION
A few oversights from changes made since the last time I ran the serverless functions in the cloud:
- Wasn't including a few necessary files since making inclusion of files stricter (one of them I made unnecessary by changing how I handled the test pipeline)
- Was writing files to the wrong `tmp` folder
- Hadn't updated some data set filenames to match what are now in the bucket
