### PR TITLE
Bump tensorflow to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ scipy==1.4.1
 # Can't install latest version as of 21-1-2020, because Google Cloud Platform
 # uses an older version of pip that doesn't recognise versions 2+ except for
 # some weird pre-release versions of 2.0.0
-tensorflow==2.0.0b0
+tensorflow==2.1.0
 
 # Kedro packages
 kedro==0.15.5


### PR DESCRIPTION
It's been awhile since I tried this, and it's impossible to find which version of `pip` Google Cloud Functions are running, so let's see what breaks.