### PR TITLE
Add ability to train models when fetching predictions

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,21 +33,35 @@ def predictions():
     round_number: Round number to predict. Predicts all rounds if omitted.
     ml_models: Comma separated names of ML models to use for predictions.
         Uses all ML models if omitted.
+    train_models (bool, optional): Whether to train each model
+        on earlier seasons' data before generating predictions
+        for a given season/round.
+        Default = False.
     """
     this_year = date.today().year
-    year_range_param = request.query.year_range or f"{this_year}-{this_year + 1}"
+    year_range_param = (
+        f"{this_year}-{this_year + 1}"
+        if request.query.year_range in [None, ""]
+        else request.query.year_range
+    )
     year_range = tuple([int(year) for year in year_range_param.split("-")])
 
     round_number = request.query.round_number
-    round_number = int(round_number) if round_number not in [None, ""] else None
+    round_number = None if round_number in [None, ""] else int(round_number)
 
     ml_models_param = request.query.ml_models
     ml_models_param = (
-        ml_models_param.split(",") if ml_models_param not in [None, ""] else None
+        None if ml_models_param in [None, ""] else ml_models_param.split(",")
     )
 
+    train_models_param = request.query.train_models
+    train_models = train_models_param.lower() == "true"
+
     return api.make_predictions(
-        year_range, round_number=round_number, ml_model_names=ml_models_param
+        year_range,
+        round_number=round_number,
+        ml_model_names=ml_models_param,
+        train=train_models,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -18,9 +18,6 @@ if SRC_PATH not in sys.path:
 from augury import api
 
 
-TRUE = "true"
-FALSE = "false"
-
 app = Bottle()
 
 

--- a/app.py
+++ b/app.py
@@ -23,7 +23,17 @@ app = Bottle()
 
 @app.route("/predictions")
 def predictions():
-    """Generate predictions for the given year and round number."""
+    """
+    Generate predictions for the given year and round number.
+
+    Accepts the following query params:
+    year_range: Range of years to predict, with the format `yyyy-yyyy`.
+        First year inclusive, second year exclusive per Python's `range` function.
+        Predicts all seasons if omitted.
+    round_number: Round number to predict. Predicts all rounds if omitted.
+    ml_models: Comma separated names of ML models to use for predictions.
+        Uses all ML models if omitted.
+    """
     this_year = date.today().year
     year_range_param = request.query.year_range or f"{this_year}-{this_year + 1}"
     year_range = tuple([int(year) for year in year_range_param.split("-")])
@@ -43,7 +53,13 @@ def predictions():
 
 @app.route("/fixtures")
 def fixtures():
-    """Fetch fixture data for the given date range."""
+    """
+    Fetch fixture data for the given date range.
+
+    Accepts the following query params:
+    start_date: The earliest date (inclusive) for which to fetch matches.
+    end_date: The latest date (inclusive) for which to fetch matches.
+    """
     start_date = request.query.start_date
     end_date = request.query.end_date
 
@@ -52,7 +68,13 @@ def fixtures():
 
 @app.route("/match_results")
 def match_results():
-    """Fetch match results data for the given date range."""
+    """
+    Fetch match results data for the given date range.
+
+    Accepts the following query params:
+    start_date: The earliest date (inclusive) for which to fetch matches.
+    end_date: The latest date (inclusive) for which to fetch matches.
+    """
     start_date = request.query.start_date
     end_date = request.query.end_date
 

--- a/main.py
+++ b/main.py
@@ -44,7 +44,11 @@ def predictions(request):
             Default = All rounds for given year.
         ml_models (str, optional): Comma-separated list of names of ML model to use
             for making predictions.
-            Default = All available models
+            Default = All available models.
+        train_models (bool, optional): Whether to train each model
+            on earlier seasons' data before generating predictions
+            for a given season/round.
+            Default = False.
 
     Returns
     -------
@@ -67,9 +71,15 @@ def predictions(request):
         else None
     )
 
+    train_models_param = request.args.get("train_models", "false")
+    train_models = train_models_param.lower() == "true"
+
     return json.dumps(
         api.make_predictions(
-            year_range, round_number=round_number, ml_model_names=ml_models_param
+            year_range,
+            round_number=round_number,
+            ml_model_names=ml_models_param,
+            train=train_models,
         )
     )
 

--- a/main.py
+++ b/main.py
@@ -18,10 +18,6 @@ if SRC_PATH not in sys.path:
 from augury import api
 
 
-TRUE = "true"
-FALSE = "false"
-
-
 def _unauthorized_response():
     return ("Not authorized", 401)
 

--- a/src/augury/api.py
+++ b/src/augury/api.py
@@ -45,7 +45,18 @@ def make_predictions(
     ml_model_names: Optional[List[str]] = None,
     train=False,
 ) -> ApiResponse:
-    """Generate match predictions with the given models for the given seasons."""
+    """Generate predictions for the given year and round number.
+
+    Params
+    ------
+    year_range: Year range for which you want prediction data. Format = yyyy-yyyy.
+    round_number: Round number for which you want prediction data.
+    ml_models: Comma-separated list of names of ML model to use for making predictions.
+
+    Returns
+    -------
+    List of prediction data dictionaries.
+    """
     context = load_context(
         BASE_DIR,
         start_date=PREDICTION_DATA_START_DATE,

--- a/src/augury/predictions.py
+++ b/src/augury/predictions.py
@@ -56,7 +56,12 @@ class Predictor:
         self.round_number = round_number
         self.train = train
         self.verbose = verbose
-        self._data = MLData(context=context, test_year_range=year_range, **data_kwargs)
+        self._data = MLData(
+            context=context,
+            train_year_range=(min(year_range),),
+            test_year_range=year_range,
+            **data_kwargs,
+        )
 
     def make_predictions(self, ml_models: List[MLModelDict]) -> pd.DataFrame:
         """Predict margins or confidence percentages for matches."""
@@ -109,6 +114,8 @@ class Predictor:
         return model_predictions
 
     def _train_model(self, ml_model: BaseMLEstimator) -> BaseMLEstimator:
+        assert max(self._data.train_year_range) <= min(self._data.test_year_range)
+
         X_train, y_train = self._data.train_data
 
         # On the off chance that we try to run predictions for years that have


### PR DESCRIPTION
This is something I used when generating initial prediction data,
but kind of got lost when I implemented the web API. This adds
the necessary query param, so the main tipresias app can force
training of models when seeding data.