### PR TITLE
Revert "Bump serverless-google-cloudfunctions from 2.4.1 to 2.4.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1898,9 +1898,9 @@
       "dev": true
     },
     "fast-text-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz",
-      "integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==",
       "dev": true
     },
     "fastq": {
@@ -4169,9 +4169,9 @@
       }
     },
     "serverless-google-cloudfunctions": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/serverless-google-cloudfunctions/-/serverless-google-cloudfunctions-2.4.2.tgz",
-      "integrity": "sha512-NMEnr2nKQeaQceRepv8AxARM+OhpS3R8uOBA17UjEaUWzJMxf3onDgiBp8A6U6smy/0KAgU9KIAX/dOFEf6oUg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/serverless-google-cloudfunctions/-/serverless-google-cloudfunctions-2.4.1.tgz",
+      "integrity": "sha512-l8RxVaah8NQeCkferhWMiNj7tkqvW6pnWMy+RBDCFYS29N52E/WxQ4Gq1u/xif+ps1lbM1crFZQ7sPTc1XbHAQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "devDependencies": {
     "serverless": "1.67.0",
-    "serverless-google-cloudfunctions": "2.4.2"
+    "serverless-google-cloudfunctions": "2.4.1"
   }
 }

--- a/src/tests/integration/data_import/test_betting_data_request.py
+++ b/src/tests/integration/data_import/test_betting_data_request.py
@@ -39,7 +39,7 @@ class TestBettingData(TestCase):
         a_month = timedelta(days=30)
         a_month_ago = today - a_month
 
-        if today > start_of_this_season and a_month_ago < end_of_this_season:
+        if today >= start_of_this_season and a_month_ago < end_of_this_season:
             self.start_date = str(a_month_ago)
         elif today < start_of_this_season:
             self.start_date = str(end_of_previous_season - a_month)


### PR DESCRIPTION
Reverts tipresias/augury#195

The new version is a breaking change for existing functions, raising the following error on deployment:
```
Error: Deployment failed: TYPE_MISMATCH
  
       Resource types cannot be changed, previous (cloudfunctions.v1beta2.function) -> updated (gcp-types/cloudfunctions-v1:projects.locations.functions)
      at throwErrorIfDeploymentFails (/app/node_modules/serverless-google-cloudfunctions/shared/monitorDeployment.js:71:11)
      at /app/node_modules/serverless-google-cloudfunctions/shared/monitorDeployment.js:42:17
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

There's a confusing web of issues/PRs linked to each other, but it seems that people are working on it.