### PR TITLE
Add missing gcloud prep for deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_script:
   # Pull & build image
   - docker pull cfranklin11/tipresias_data_science:latest
   - docker build --cache-from cfranklin11/tipresias_data_science:latest -t cfranklin11/tipresias_data_science:latest -f Dockerfile.local .
-  # Set up Google Cloud credentials
-  - mkdir ${HOME}/.gcloud
+  # Set up gcloud authentication
+  - mkdir $HOME/.gcloud
   - openssl aes-256-cbc -K $encrypted_241002f0ef4b_key -iv $encrypted_241002f0ef4b_iv -in keyfile.json.enc -out ${HOME}/.gcloud/keyfile.json -d
   # Set up test coverage monitoring
   - ./cc-test-reporter before-build
@@ -38,8 +38,20 @@ after_script:
   - ./cc-test-reporter format-coverage -t coverage.py
   - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi
 before_deploy:
+  # Push docker image
   - echo "$DOCKER_PASSWORD" | docker login -u cfranklin11 --password-stdin
   - docker push cfranklin11/tipresias_data_science:latest
+  # Prepare gcloud tool for deployment
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud --quiet version
+  - gcloud --quiet components install beta
+  - gcloud --quiet components update
+  - gcloud auth activate-service-account --key-file ${HOME}/.gcloud/keyfile.json
+  - gcloud --quiet config set project $PROJECT_ID
+  # Need travis_wait for the deploy script for the same reason as for the docker build command
+  - export -f travis_wait
+  - export -f travis_jigger
 deploy:
   provider: script
   script: ./scripts/deploy.sh


### PR DESCRIPTION
When I copy/pasted .travis.yml changes from bird-signs, I missed
this part. We need this for gcloud not to raise errors while
deploying from CI.