### PR TITLE
Fix data set errors in production

### DIFF
--- a/conf/local/catalog.yml
+++ b/conf/local/catalog.yml
@@ -18,22 +18,22 @@ player_data:
 # Intermediate data
 final_betting_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/betting-data_2010-01-01_2019-12-31.json
+  filepath: /app/data/02_intermediate/betting-data_2010-01-01_2020-12-31.json
   save_args:
     indent: 2
 final_match_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/match-data_1897-01-01_2019-12-31.json
+  filepath: /app/data/02_intermediate/match-data_1897-01-01_2020-12-31.json
   save_args:
     indent: 2
 final_legacy_match_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/legacy-match-data_1897-01-01_2019-12-31.json
+  filepath: /app/data/02_intermediate/legacy-match-data_1897-01-01_2020-12-31.json
   save_args:
     indent: 2
 final_player_data:
   type: JSONLocalDataSet
-  filepath: /app/data/02_intermediate/player-data_1965-01-01_2019-12-31.json
+  filepath: /app/data/02_intermediate/player-data_1965-01-01_2020-12-31.json
   save_args:
     indent: 2
 

--- a/conf/production/catalog.yml
+++ b/conf/production/catalog.yml
@@ -15,11 +15,11 @@ player_data:
 # Final data
 legacy_model_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: legacy-model-data_1897-01-01_2019-12-31.json
+  filepath: legacy-model-data_1897-01-01_2020-12-31.json
   bucket_name: afl_data
 model_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: model-data_1897-01-01_2019-12-31.json
+  filepath: model-data_1897-01-01_2020-12-31.json
   bucket_name: afl_data
 
 # Models

--- a/conf/production/logging.yml
+++ b/conf/production/logging.yml
@@ -26,5 +26,5 @@ loggers:
     propagate: no
 
 root:
-  level: INFO
+  level: WARNING
   handlers: [console]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -8,6 +8,12 @@ services:
       - ./:/app
     ports:
       - "8008:8008"
+    deploy:
+      resources:
+        limits:
+          # We set the memory limit to the max allowed for Google Cloud Run
+          # to try to catch potential crashes in CI rather than prod
+          memory: 2048M
     depends_on:
       - afl_data
     environment:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,7 @@ fi
 
 gcloud beta run deploy augury \
   --image gcr.io/${PROJECT_ID}/augury \
-  --memory 2Gi \
+  --memory 2048Mi \
   --region us-central1 \
   --platform managed \
   --update-env-vars AFL_DATA_SERVICE_TOKEN=${AFL_DATA_SERVICE_TOKEN},PYTHON_ENV=production,DATA_SCIENCE_SERVICE_TOKEN=${DATA_SCIENCE_SERVICE_TOKEN},AFL_DATA_SERVICE=${AFL_DATA_SERVICE}

--- a/src/augury/api.py
+++ b/src/augury/api.py
@@ -72,6 +72,7 @@ def make_predictions(
         round_number=context.round_number,  # type: ignore
         train=train,
         verbose=1,
+        update_data=True,
     )
 
     if ml_model_names is None:

--- a/src/augury/io/json_gc_storage_data_set.py
+++ b/src/augury/io/json_gc_storage_data_set.py
@@ -48,3 +48,9 @@ class JSONGCStorageDataSet(AbstractDataSet):
 
     def _describe(self) -> Dict[str, Any]:
         return dict(filepath=self._filepath, bucket_name=self._bucket_name)
+
+    def _exists(self) -> bool:
+        client = storage.Client()
+        bucket = client.get_bucket(self._bucket_name)
+
+        return storage.Blob(bucket=bucket, name=self._filepath).exists(client)

--- a/src/augury/io/json_gc_storage_data_set.py
+++ b/src/augury/io/json_gc_storage_data_set.py
@@ -9,8 +9,6 @@ dev environment).
 from typing import Any, Dict, List
 import json
 
-import pandas as pd
-
 from kedro.io.core import AbstractDataSet
 from google.cloud import storage
 
@@ -43,8 +41,15 @@ class JSONGCStorageDataSet(AbstractDataSet):
 
         return json.loads(blob.download_as_string())
 
-    def _save(self, data: pd.DataFrame) -> None:
-        pass
+    def _save(self, data: List[Dict[str, Any]]) -> None:
+        client = storage.Client()
+
+        bucket = client.get_bucket(self._bucket_name)
+        blob = storage.Blob(self._filepath, bucket)
+
+        blob.upload_from_string(
+            json.dumps(data, indent=2), content_type="application/json"
+        )
 
     def _describe(self) -> Dict[str, Any]:
         return dict(filepath=self._filepath, bucket_name=self._bucket_name)

--- a/src/augury/nodes/common.py
+++ b/src/augury/nodes/common.py
@@ -56,9 +56,9 @@ def _append_data_frames(
     # Assumes the following:
     #     - All data frames have a date column
     #     - Data frames are sorted by date in ascending order
+    #       (the data frames themselves, not their rows)
     #     - Data frames have all data for a given date (i.e. all matches played
     #         on a date, not 1 of 3, which would result in missing data)
-
     max_accumulated_date = acc_data_frame[  # pylint: disable=unused-variable
         "date"
     ].max()


### PR DESCRIPTION
A few data set errors that slipped through the cracks while all "past" data was still in 2019:

- Wasn't updating data when calling `make_predictions` with matches from the current season
- Some data-set filepaths hadn't been updated for 2020
- My hacky implementation of a Kedro data set for Google Cloud Storage was missing some methods (`_exists`, `_save`) that apparently I needed.

I'm a little concerned with the Google Cloud Run memory limit, because I'm bumping right up against it when running `make_predictions` on local, but it was able to run in Google Cloud Functions, which has the same limit, so fingers crossed it'll still work.