### PR TITLE
Only use data from last 10 years for prod predictions

### DIFF
--- a/conf/production/catalog.yml
+++ b/conf/production/catalog.yml
@@ -5,21 +5,21 @@ betting_data:
   bucket_name: afl_data
 match_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: match-data_1897-01-01_2019-12-31.json
+  filepath: match-data_2010-01-01_2019-12-31.json
   bucket_name: afl_data
 player_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: player-data_1965-01-01_2019-12-31.json
+  filepath: player-data_2010-01-01_2019-12-31.json
   bucket_name: afl_data
 
 # Final data
 legacy_model_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: legacy-model-data_1897-01-01_2020-12-31.json
+  filepath: legacy-model-data_2010-01-01_2020-12-31.json
   bucket_name: afl_data
 model_data:
   type: augury.io.JSONGCStorageDataSet
-  filepath: model-data_1897-01-01_2020-12-31.json
+  filepath: model-data_2010-01-01_2020-12-31.json
   bucket_name: afl_data
 
 # Models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     depends_on:
       - data_science
     environment:
-      - PYTHON_ENV=development
+      - PYTHON_ENV=local
       - GIT_PYTHON_REFRESH=silence
     command: kedro jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
   mlflow:


### PR DESCRIPTION
Based on how we calculate various rolling averages, we don't
need any data from before 10 years ago to build features for
prediction matches for this year. Since loading the raw match
and player data sets are crashing Google Cloud Run due to the
memory usage, we need to drop unused data to make it work.