### PR TITLE
Fix bits calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,9 @@ from augury.types import YearRange
 
 
 IS_PRODUCTION = os.getenv("PYTHON_ENV", "").lower() == "production"
-TIPRESIAS_HOST = "tipresias.net"
+TIPRESIAS_HOST = (
+    "tipresias.net" if IS_PRODUCTION else "http://host.docker.internal:8000"
+)
 
 app = Bottle()
 
@@ -67,11 +69,10 @@ def _send_predictions(
         train=train,
     )
 
-    if IS_PRODUCTION:
-        url = urljoin(TIPRESIAS_HOST, "predictions")
-        headers = {"Authorization": f'Bearer {os.environ["TIPRESIAS_APP_TOKEN"]}'}
+    url = urljoin(TIPRESIAS_HOST, "predictions")
+    headers = {"Authorization": f'Bearer {os.environ["TIPRESIAS_APP_TOKEN"]}'}
 
-        requests.post(url, json=prediction_data, headers=headers)
+    requests.post(url, json=prediction_data, headers=headers)
 
 
 @app.route("/predictions")

--- a/src/augury/predictions.py
+++ b/src/augury/predictions.py
@@ -94,6 +94,12 @@ class Predictor:
         )
 
         y_pred = trained_model.predict(X_test)
+
+        assert not any(np.isnan(y_pred)), (
+            f"Predictions should never be NaN, but {trained_model.name} predicted:\n"
+            f"{y_pred}."
+        )
+
         data_row_slice = (
             slice(None),
             year,

--- a/src/augury/predictions.py
+++ b/src/augury/predictions.py
@@ -72,6 +72,9 @@ class Predictor:
             for year in range(*self.year_range)
         ]
 
+        if self.verbose == 1:
+            print("Finished making predictions!")
+
         return pd.concat(list(itertools.chain.from_iterable(predictions)), sort=False)
 
     def _make_predictions_by_year(self, ml_models, year: int) -> List[pd.DataFrame]:

--- a/src/tests/unit/test_sklearn.py
+++ b/src/tests/unit/test_sklearn.py
@@ -362,14 +362,21 @@ class TestSklearn(TestCase, KedroContextMixin):
         self.assertIsInstance(hess, np.ndarray)
         self.assertEqual(hess.dtype, "float64")
 
-        with self.subTest("when some predictions equal 1"):
-            warnings.filterwarnings(
-                "error",
-                category=RuntimeWarning,
-                message="divide by zero encountered in true_divide",
-            )
+        warnings.filterwarnings(
+            "error",
+            category=RuntimeWarning,
+            message="divide by zero encountered in true_divide",
+        )
 
+        with self.subTest("when some predictions equal 1"):
             y_pred[:5] = np.ones(5)
+
+            # Will raise a divide-by-zero error if a y_pred value of 1 gets through,
+            # so we don't need to assert anything
+            bits_objective(y_true, y_pred)
+
+        with self.subTest("when some predictions equal 0"):
+            y_pred[:5] = np.zeros(5)
 
             # Will raise a divide-by-zero error if a y_pred value of 1 gets through,
             # so we don't need to assert anything


### PR DESCRIPTION
As with an earlier fix for predictions of 1, predictions of 0 have to be bumped up to ever-so-slightly-more-than-0 in order to avoid divided-by-zero errors when calculating gradients during training.