### PR TITLE
Run pipelines as main thread

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ services:
   - docker
 env:
   global:
-    DOCKER_COMPOSE_VERSION: 1.22.0
+    DOCKER_COMPOSE_VERSION: 1.25.5
     GOOGLE_APPLICATION_CREDENTIALS: .gcloud/keyfile.json
     CC_TEST_REPORTER_ID: 3c6e7d3ecb1089284ed54da495ee9062362337415223df4c122dc68b575dd708
 install:
   # Install docker-compose
   - sudo rm /usr/local/bin/docker-compose
-  - sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  - sudo curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64" -o /usr/local/bin/docker-compose
   - sudo chmod +x /usr/local/bin/docker-compose
   # Install test coverage monitoring
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ from typing import Dict, Any, Optional, List
 import os
 import sys
 from datetime import date
-from threading import Thread
 from urllib.parse import urljoin
 
 import requests
@@ -122,17 +121,16 @@ def predictions():
     train_models_param = request.query.train_models
     train_models = train_models_param.lower() == "true"
 
-    thread = Thread(
-        target=_send_predictions,
-        args=(year_range,),
-        kwargs={
-            "round_number": round_number,
-            "ml_model_names": ml_models_param,
-            "train": train_models,
-        },
+    _send_predictions(
+        year_range,
+        round_number=round_number,
+        ml_model_names=ml_models_param,
+        train=train_models,
     )
-    thread.start()
 
+    # I don't actually expect this to get returned, as data processing takes too long
+    # for an HTTP request, but might as well give a response in case anyone
+    # is still listening
     response.status = 202
 
     return {

--- a/src/augury/api.py
+++ b/src/augury/api.py
@@ -1,25 +1,24 @@
 """The public API for the Augury app."""
 
 from typing import List, Optional, Dict, Union, Any
-from datetime import date
 
 import pandas as pd
 from mypy_extensions import TypedDict
-from kedro.context import load_context, KedroContext
+from kedro.context import KedroContext
 import simplejson
 
 from augury.data_import import match_data
 from augury.nodes import match
 from augury.predictions import Predictor
 from augury.types import YearRange, MLModelDict
-from augury.settings import ML_MODELS, PREDICTION_DATA_START_DATE, BASE_DIR
+from augury.settings import ML_MODELS
+from augury.context import load_project_context
 
 
 ApiResponse = TypedDict(
     "ApiResponse", {"data": Union[List[Dict[str, Any]], Dict[str, Any]]}
 )
 
-END_OF_YEAR = f"{date.today().year}-12-31"
 PIPELINE_NAMES = {"model_data": "full", "legacy_model_data": "legacy"}
 
 
@@ -65,12 +64,7 @@ def make_predictions(
     -------
     List of prediction data dictionaries.
     """
-    context = load_context(
-        BASE_DIR,
-        start_date=PREDICTION_DATA_START_DATE,
-        end_date=END_OF_YEAR,
-        round_number=round_number,
-    )
+    context = load_project_context(round_number=round_number)
 
     if ml_model_names is None:
         ml_models = ML_MODELS

--- a/src/augury/context.py
+++ b/src/augury/context.py
@@ -1,0 +1,34 @@
+"""Customizations for Kedro's context module."""
+
+from typing import Optional
+from datetime import date
+import os
+
+from kedro.context import load_context
+
+from augury.settings import BASE_DIR, PREDICTION_DATA_START_DATE
+
+
+END_OF_YEAR = f"{date.today().year}-12-31"
+
+
+def load_project_context(round_number: Optional[int] = None, **context_kwargs):
+    """Load a Kedro context specific to this project and the current environment."""
+    kedro_env = (
+        "production"
+        if os.environ.get("CI", "").lower() == "true"
+        else os.environ.get("PYTHON_ENV")
+    )
+    date_kwargs = (
+        {"start_date": PREDICTION_DATA_START_DATE, "end_date": END_OF_YEAR}
+        if os.getenv("PYTHON_ENV", "").lower() == "production"
+        else {}
+    )
+
+    return load_context(
+        BASE_DIR,
+        env=kedro_env,
+        round_number=round_number,
+        **date_kwargs,
+        **context_kwargs,
+    )

--- a/src/augury/ml_data.py
+++ b/src/augury/ml_data.py
@@ -4,15 +4,15 @@ from typing import Tuple, Optional, List
 from datetime import date
 
 import pandas as pd
-from kedro.context import load_context, KedroContext
+from kedro.context import KedroContext
 
 from augury.types import YearRange
 from augury.settings import (
-    BASE_DIR,
     INDEX_COLS,
     TRAIN_YEAR_RANGE,
     VALIDATION_YEAR_RANGE,
 )
+from augury.context import load_project_context
 
 
 END_OF_YEAR = f"{date.today().year}-12-31"
@@ -44,7 +44,7 @@ class MLData:
         index_cols: Column names to use for the DataFrame's index.
         label_col: Name of the column to use for data labels (i.e. y data set).
         """
-        self.context = context or load_context(BASE_DIR)
+        self.context = context or load_project_context()
         self._data_set = data_set
         self._train_year_range = train_year_range
         self._test_year_range = test_year_range

--- a/src/tests/helpers.py
+++ b/src/tests/helpers.py
@@ -1,10 +1,6 @@
 """Functions and classes to deduplicate and simplify test code."""
 
-import os
-
-from kedro.context import load_context
-
-from augury.settings import BASE_DIR
+from augury.context import load_project_context
 
 
 class KedroContextMixin:
@@ -17,13 +13,7 @@ class KedroContextMixin:
         Need to use production environment for loading data sets if in CI, because we
         don't check data set files into source control
         """
-        kedro_env = (
-            "production"
-            if os.environ.get("CI") == "true"
-            else os.environ.get("PYTHON_ENV")
-        )
-
-        return load_context(BASE_DIR, env=kedro_env, **context_kwargs)
+        return load_project_context(**context_kwargs)
 
 
 class ColumnAssertionMixin:


### PR DESCRIPTION
Google Cloud Run doesn't support background processes, so it just
kills it shortly after returning the HTTP response. The solution
is to just let the client get a timeout or connection closed error
while augury keeps processing data, then we can POST the predictions
to the main app's predictions.