### PR TITLE
Change paste to gunicorn for server

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,10 @@ def _run_kwargs():
         "port": int(os.getenv("PORT", "8008")),
         "reloader": not IS_PRODUCTION,
         "host": "0.0.0.0",
-        "server": "paste",
+        "server": "gunicorn",
+        "accesslog": "-",
+        "timeout": 1200,
+        "workers": 3,
     }
 
     return run_kwargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ google-cloud-storage==1.28.1
 joblib
 simplejson
 bottle==0.12.18
-paste==3.4.0
+gunicorn
 
 # Data packages
 numpy==1.18.4


### PR DESCRIPTION
I changed from gunicorn to paste earlier, because I was getting
errors from gunicorn that turned out to be simple timeouts.
I looked into extending the paste timeout, but their documentation
isn't great, so going back to gunicorn, which I understand a bit
better.