### PR TITLE
Translate team names for roster data

### DIFF
--- a/src/augury/nodes/betting.py
+++ b/src/augury/nodes/betting.py
@@ -10,6 +10,7 @@ from .base import (
     _validate_required_columns,
     _validate_unique_team_index_columns,
     _filter_out_dodgy_data,
+    _validate_canoncial_team_names,
 )
 
 
@@ -51,6 +52,7 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
     )
 
     _validate_unique_team_index_columns(clean_betting_data)
+    _validate_canoncial_team_names(clean_betting_data)
 
     return clean_betting_data
 

--- a/src/augury/nodes/match.py
+++ b/src/augury/nodes/match.py
@@ -24,6 +24,7 @@ from .base import (
     _filter_out_dodgy_data,
     _convert_id_to_string,
     _validate_unique_team_index_columns,
+    _validate_canoncial_team_names,
 )
 
 
@@ -142,6 +143,7 @@ def clean_match_data(match_data: pd.DataFrame) -> pd.DataFrame:
         )
 
         _validate_unique_team_index_columns(clean_data)
+        _validate_canoncial_team_names(clean_data)
 
         return clean_data
 
@@ -229,6 +231,7 @@ def clean_fixture_data(fixture_data: pd.DataFrame) -> pd.DataFrame:
     )
 
     _validate_unique_team_index_columns(fixture_data_frame)
+    _validate_canoncial_team_names(fixture_data_frame)
 
     return fixture_data_frame
 

--- a/src/augury/nodes/player.py
+++ b/src/augury/nodes/player.py
@@ -13,6 +13,7 @@ from .base import (
     _filter_out_dodgy_data,
     _convert_id_to_string,
     _validate_required_columns,
+    _validate_canoncial_team_names,
 )
 
 PLAYER_COL_TRANSLATIONS = {
@@ -120,7 +121,7 @@ def clean_player_data(
         ]
     )
 
-    return (
+    cleaned_player_data = (
         player_data.rename(columns=PLAYER_COL_TRANSLATIONS)
         .astype({"year": int})
         .assign(
@@ -163,6 +164,10 @@ def clean_player_data(
         .set_index("id")
         .sort_index()
     )
+
+    _validate_canoncial_team_names(cleaned_player_data)
+
+    return cleaned_player_data
 
 
 def clean_roster_data(
@@ -210,6 +215,8 @@ def clean_roster_data(
     roster_data_frame["player_id"].fillna(
         roster_data_frame["player_name"], inplace=True
     )
+
+    _validate_canoncial_team_names(roster_data_frame)
 
     return roster_data_frame.assign(id=_player_id_col).set_index("id")
 

--- a/src/augury/nodes/player.py
+++ b/src/augury/nodes/player.py
@@ -184,7 +184,12 @@ def clean_roster_data(
     )
 
     roster_data_frame = (
-        roster_data.assign(date=_parse_dates)
+        roster_data.assign(
+            date=_parse_dates,
+            home_team=_translate_team_column("home_team"),
+            away_team=_translate_team_column("away_team"),
+            playing_for=_translate_team_column("playing_for"),
+        )
         .query("date > @start_of_today")
         .rename(columns={"season": "year"})
         .merge(

--- a/src/augury/settings.py
+++ b/src/augury/settings.py
@@ -67,6 +67,8 @@ TEAM_TRANSLATIONS = {
     "Sydney Swans": "Sydney",
 }
 
+CANONICAL_TEAM_NAMES = set(TEAM_TRANSLATIONS.values())
+
 # For when we fetch upcoming matches in the fixture and need to make Footywire venue
 # names consistent with AFL tables venue names
 FOOTYWIRE_VENUE_TRANSLATIONS = {


### PR DESCRIPTION
The new version of the AFL roster page uses some variations of
team names that differ from our canonical versions, so we have
to add the team mapping that we use in other data sets.