### PR TITLE
Fix team name list for validation & add env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,13 +38,16 @@ services:
     image: augury_data_science:latest
     volumes:
       - ./:/app
+      - ./.gcloud:/app/.gcloud
     ports:
       - "8888:8888"
     depends_on:
       - data_science
+    env_file: .env
     environment:
       - PYTHON_ENV=local
       - GIT_PYTHON_REFRESH=silence
+      - GOOGLE_APPLICATION_CREDENTIALS=.gcloud/keyfile.json
     command: kedro jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
   mlflow:
     image: augury_data_science:latest

--- a/src/augury/nodes/base.py
+++ b/src/augury/nodes/base.py
@@ -12,7 +12,7 @@ from augury.settings import (
     TEAM_TRANSLATIONS,
     INDEX_COLS,
     VENUE_TIMEZONES,
-    CANONICAL_TEAM_NAMES,
+    TEAM_NAMES,
 )
 
 
@@ -149,7 +149,7 @@ def _validate_canoncial_team_names(data_frame: pd.DataFrame):
 
     cols_to_check = list(set(data_frame.columns) & set(TEAM_NAME_COLS))
     unique_team_names = set(data_frame[cols_to_check].to_numpy().flatten())
-    non_canonical_team_names = unique_team_names - CANONICAL_TEAM_NAMES
+    non_canonical_team_names = unique_team_names - set(TEAM_NAMES)
 
     assert not any(non_canonical_team_names), (
         "All team names must be the canonical versions or table joins won't work. "

--- a/src/augury/settings.py
+++ b/src/augury/settings.py
@@ -67,8 +67,6 @@ TEAM_TRANSLATIONS = {
     "Sydney Swans": "Sydney",
 }
 
-CANONICAL_TEAM_NAMES = set(TEAM_TRANSLATIONS.values())
-
 # For when we fetch upcoming matches in the fixture and need to make Footywire venue
 # names consistent with AFL tables venue names
 FOOTYWIRE_VENUE_TRANSLATIONS = {


### PR DESCRIPTION
A couple of little fixes while trying to debug prediction discrepancies between `local` and `production` data sets.

- Use correct team names list
- Add `data_science` env vars to `notebook`