### PR TITLE
 Deploy to Google Cloud Run again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,14 @@ before_deploy:
   # Push docker image
   - echo "$DOCKER_PASSWORD" | docker login -u cfranklin11 --password-stdin
   - docker push cfranklin11/tipresias_data_science:latest
+  # Prepare gcloud tool for deployment
+  - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk; export CLOUDSDK_CORE_DISABLE_PROMPTS=1; curl https://sdk.cloud.google.com | bash; fi
+  - source /home/travis/google-cloud-sdk/path.bash.inc
+  - gcloud --quiet version
+  - gcloud --quiet components install beta
+  - gcloud --quiet components update
+  - gcloud auth activate-service-account --key-file ${HOME}/.gcloud/keyfile.json
+  - gcloud --quiet config set project $PROJECT_ID
 deploy:
   provider: script
   script: ./scripts/deploy.sh

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ def _run_kwargs():
         "server": "gunicorn",
         "accesslog": "-",
         "timeout": 1200,
-        "workers": 3,
+        "workers": 1,
     }
 
     return run_kwargs

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,9 +2,43 @@
 
 set -euo pipefail
 
+PORT=8008
+
+# We need travis_wait for Travis CI builds, because installing R packages takes forever.
+# On a local machine, we can just build & deploy as normal.
+if [ -n "$(LC_ALL=C type -t travis_wait)" ] && [ "$(LC_ALL=C type -t travis_wait)" = function ]
+then
+  travis_wait 30 gcloud builds submit --config cloudbuild.yaml
+else
+  gcloud builds submit --config cloudbuild.yaml
+fi
+
+GOOGLE_ENV_VARS="
+  AFL_DATA_SERVICE_TOKEN=${AFL_DATA_SERVICE_TOKEN},\
+  PYTHON_ENV=production,\
+  DATA_SCIENCE_SERVICE_TOKEN=${DATA_SCIENCE_SERVICE_TOKEN},\
+  AFL_DATA_SERVICE=${AFL_DATA_SERVICE},\
+  TIPRESIAS_APP_TOKEN=${TIPRESIAS_APP_TOKEN}
+"
+
+gcloud beta run deploy augury \
+  --image gcr.io/${PROJECT_ID}/augury \
+  --memory 2048Mi \
+  --region us-central1 \
+  --platform managed \
+  --update-env-vars ${GOOGLE_ENV_VARS}
+./backend/scripts/wait-for-it.sh ${GCR_HOST}:${PORT} \
+  -t 60 \
+  -- ./scripts/post_deploy.sh
+
+if [ $? != 0 ]
+then
+  exit $?
+fi
+
+
 APP_DIR=/var/www/${PROJECT_ID}
 DOCKER_IMAGE=cfranklin11/tipresias_data_science:latest
-PORT=8008
 
 sudo chmod 600 ~/.ssh/deploy_rsa
 sudo chmod 755 ~/.ssh


### PR DESCRIPTION
Now that I've fixed the various timeout and memory limit bugs
and found that the problem wasn't Google Cloud Run after all,
I'm going to try deploying to GCR again. I'll keep the
DigitalOcean server for now to make sure this works.