### PR TITLE
Handle empty data without 'date' column

### DIFF
--- a/src/augury/nodes/common.py
+++ b/src/augury/nodes/common.py
@@ -29,10 +29,17 @@ def convert_to_data_frame(
     -------
     Sequence of pandas.DataFrame
     """
-    data_frames = [
-        pd.DataFrame(datum).assign(date=lambda df: pd.to_datetime(df["date"]))
-        for datum in data
-    ]
+    if len(data) == 0:
+        return pd.DataFrame()
+
+    data_frames = [pd.DataFrame(datum) for datum in data]
+
+    # TODO: Quick fix for empty roster data not having a 'date' column.
+    # We should figure out a better way to handle empty data such that
+    # its shape/columns are consistent, but one doesn't occur to me at the moment.
+    for df in data_frames:
+        if "date" in df.columns:
+            df.loc[:, "date"] = pd.to_datetime(df["date"])
 
     return data_frames if len(data_frames) > 1 else data_frames[0]
 

--- a/src/tests/unit/nodes/test_common.py
+++ b/src/tests/unit/nodes/test_common.py
@@ -50,6 +50,16 @@ class TestCommon(TestCase, ColumnAssertionMixin):
 
         self.assertEqual(set(raw_data_fields), set(data_frame_columns))
 
+        with self.subTest("when data is empty"):
+            data = []
+
+            data_frames = common.convert_to_data_frame(data)
+
+            # It is an empty data frame with no columns
+            self.assertIsInstance(data_frames, pd.DataFrame)
+            self.assertEqual(len(data_frames), 0)
+            self.assertFalse(any(data_frames.columns))
+
     def test_combine_data(self):
         raw_betting_data = fake_footywire_betting_data(
             N_MATCHES_PER_SEASON, YEAR_RANGE, clean=False


### PR DESCRIPTION
Sometimes the data from APIs, especially rosters, come back empty,
so we have to be able to handle that. This fix is far from elegant,
but we'll have the chance to improve it when we implement kedro's
API data set for these imports.