### PR TITLE
Temporarily drop duplicates from fixture data

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,7 +120,7 @@ def fixtures():
     Request with the following URL params:
         start_date (string of form 'yyyy-mm-dd', required): Start of date range
             (inclusive) for which you want data.
-        start_date (string of form 'yyyy-mm-dd', required): End of date range
+        end_date (string of form 'yyyy-mm-dd', required): End of date range
             (inclusive) for which you want data.
 
     Returns
@@ -146,7 +146,7 @@ def match_results():
     Request with the following URL params:
         start_date (string of form 'yyyy-mm-dd', required): Start of date range
             (inclusive) for which you want data.
-        start_date (string of form 'yyyy-mm-dd', required): End of date range
+        end_date (string of form 'yyyy-mm-dd', required): End of date range
             (inclusive) for which you want data.
 
     Returns

--- a/src/augury/nodes/base.py
+++ b/src/augury/nodes/base.py
@@ -158,14 +158,14 @@ def _validate_canoncial_team_names(data_frame: pd.DataFrame):
     )
 
 
-def _filter_out_dodgy_data(duplicate_subset=None) -> Callable:
+def _filter_out_dodgy_data(keep="last", **kwargs) -> Callable:
     return lambda df: (
         df.sort_values("date", ascending=True)
         # Some early matches (1800s) have fully-duplicated rows.
         # Also, drawn finals get replayed, which screws up my indexing and a bunch of other
-        # data munging, so getting match_ids for the repeat matches, and filtering
-        # them out of the data frame
-        .drop_duplicates(subset=duplicate_subset, keep="last")
+        # data munging, so we keep the 'last' finals played, which is the one
+        # that didn't end in a tie.
+        .drop_duplicates(keep=keep, **kwargs)
         # There were some weird round-robin rounds in the early days, and it's easier to
         # drop them rather than figure out how to split up the rounds.
         .query(

--- a/src/augury/nodes/betting.py
+++ b/src/augury/nodes/betting.py
@@ -29,7 +29,7 @@ def clean_data(betting_data: pd.DataFrame) -> pd.DataFrame:
         betting_data.rename(columns={"season": "year", "round": "round_number"})
         .pipe(
             _filter_out_dodgy_data(
-                duplicate_subset=["year", "round_number", "home_team", "away_team"]
+                subset=["year", "round_number", "home_team", "away_team"]
             )
         )
         .drop(

--- a/src/augury/nodes/match.py
+++ b/src/augury/nodes/match.py
@@ -128,7 +128,7 @@ def clean_match_data(match_data: pd.DataFrame) -> pd.DataFrame:
             .astype({"year": int, "round_number": int})
             .pipe(
                 _filter_out_dodgy_data(
-                    duplicate_subset=["year", "round_number", "home_team", "away_team"]
+                    subset=["year", "round_number", "home_team", "away_team"]
                 )
             )
             .assign(

--- a/src/augury/nodes/match.py
+++ b/src/augury/nodes/match.py
@@ -228,6 +228,20 @@ def clean_fixture_data(fixture_data: pd.DataFrame) -> pd.DataFrame:
             match_id=_match_id_column,
         )
         .fillna(0)
+        # TEMPORARY fix for bad round numbers in the fixture data due to the AFL
+        # scheduling a constant run of matches to finish out the season as early as
+        # possible. The upcoming round is still okay, but we'll need to fix
+        # the data source before the next round.
+        .pipe(
+            _filter_out_dodgy_data(
+                subset=["year", "round_number", "home_team"], keep="first"
+            )
+        )
+        .pipe(
+            _filter_out_dodgy_data(
+                subset=["year", "round_number", "away_team"], keep="first"
+            )
+        )
     )
 
     _validate_unique_team_index_columns(fixture_data_frame)

--- a/src/augury/nodes/player.py
+++ b/src/augury/nodes/player.py
@@ -148,11 +148,7 @@ def clean_player_data(
         # from match_results. Also, match_results round_numbers are integers rather than
         # a mix of ints and strings.
         .merge(cleaned_match_data, on=["merge_date", "venue"], how="left")
-        .pipe(
-            _filter_out_dodgy_data(
-                duplicate_subset=["year", "round_number", "player_id"]
-            )
-        )
+        .pipe(_filter_out_dodgy_data(subset=["year", "round_number", "player_id"]))
         .drop(["venue", "merge_date"], axis=1)
         # brownlow_votes aren't known until the end of the season
         .fillna({"brownlow_votes": 0})


### PR DESCRIPTION
Due to the AFL jamming a whole bunch of matches in a short period of time, the usual calculation of round numbers in `fitzRoy` doesn't work for the upcoming rounds. This fix will get us through this week's round, but I'll have to open a PR on `fitzRoy` to fix round calculations for the following rounds. After that gets merged, I'll be able to remove the `drop_duplicates` from cleaning fixture data.