### PR TITLE
Rename match_results to matches

### DIFF
--- a/app.py
+++ b/app.py
@@ -159,7 +159,33 @@ def match_results():
     start_date = request.query.start_date
     end_date = request.query.end_date
 
-    return api.fetch_match_results_data(start_date, end_date)
+    return api.fetch_match_data(start_date, end_date)
+
+
+@app.route("/matches")
+def matches():
+    """
+    Fetch match data for the given date range.
+
+    Params
+    ------
+    Request with the following URL params:
+        start_date (string of form 'yyyy-mm-dd', required): Start of date range
+            (inclusive) for which you want data.
+        end_date (string of form 'yyyy-mm-dd', required): End of date range
+            (inclusive) for which you want data.
+
+    Returns
+    -------
+    Response with a body that has a JSON of match data.
+    """
+    if not _request_is_authorized(request):
+        return _unauthorized_response()
+
+    start_date = request.query.start_date
+    end_date = request.query.end_date
+
+    return api.fetch_match_data(start_date, end_date)
 
 
 @app.route("/ml_models")

--- a/src/augury/api.py
+++ b/src/augury/api.py
@@ -117,11 +117,11 @@ def fetch_fixture_data(
     )
 
 
-def fetch_match_results_data(
+def fetch_match_data(
     start_date: str, end_date: str, data_import=match_data, verbose: int = 1
 ) -> ApiResponse:
     """
-    Fetch results data for past matches from afl_data service.
+    Fetch data for past matches from afl_data service.
 
     Params
     ------
@@ -133,7 +133,7 @@ def fetch_match_results_data(
 
     Returns
     -------
-    List of match results data dictionaries.
+    List of match data dictionaries.
     """
     return _api_response(
         pd.DataFrame(

--- a/src/tests/unit/test_api.py
+++ b/src/tests/unit/test_api.py
@@ -89,13 +89,13 @@ class TestApi(TestCase):
         fixture_years = list({match["year"] for match in matches})
         self.assertEqual(fixture_years, [YEAR_RANGE[0]])
 
-    def test_fetch_match_results_data(self):
+    def test_fetch_match_data(self):
         data_importer = match_data
         data_importer.fetch_match_data = Mock(
             return_value=fake_raw_match_results_data(N_MATCHES, YEAR_RANGE)
         )
 
-        response = api.fetch_match_results_data(
+        response = api.fetch_match_data(
             "2019-01-01", "2019-12-31", data_import=data_importer, verbose=0
         )
 


### PR DESCRIPTION
I want to use match_results for the new data source. The existing
match data is more than just results, so it makes sense to refer
to it as "match data" and the new data source as "match results
data".