### PR TITLE
Drop extra index level created by group_keys

### DIFF
--- a/src/augury/nodes/feature_calculation.py
+++ b/src/augury/nodes/feature_calculation.py
@@ -106,6 +106,7 @@ def _rolling_rate(column: str, data_frame: pd.DataFrame) -> pd.Series:
 
     return (
         rolling_rate_filled_by_expanding_rate(groups, AVG_SEASON_LENGTH)
+        .droplevel(level=0)
         .dropna()
         .sort_index()
         .rename(f"rolling_{column}_rate")

--- a/src/tests/unit/nodes/test_feature_calculation.py
+++ b/src/tests/unit/nodes/test_feature_calculation.py
@@ -42,6 +42,18 @@ class TestFeatureCalculations(TestCase):
         self.assertIsInstance(calculated_data_frame, pd.DataFrame)
         self.assertFalse(any(calculated_data_frame.columns.duplicated()))
 
+        with self.subTest("with calculate_rolling_rate"):
+            calculators = [(feature_calculation.calculate_rolling_rate, [("score",)])]
+
+            with self.subTest("with a multi-indexed data frame"):
+                multi_index_df = self.data_frame.set_index(
+                    ["team", "year", "round_number"], drop=False
+                )
+
+                # It runs without error
+                calc_function = feature_calculation.feature_calculator(calculators)
+                calc_function(multi_index_df)
+
     def test_rolling_rate_filled_by_expanding_rate(self):
         groups = self.data_frame[["team", "score", "oppo_score"]].groupby("team")
         window = 10


### PR DESCRIPTION
I remembered to drop the level in the player feature calculation,
but not for the generic rolling rate calculation, which caused
an error when it was used in the feature_calculator function.