### PR TITLE
Include fixture from up to a week ago

### DIFF
--- a/src/augury/io/json_remote_data_set.py
+++ b/src/augury/io/json_remote_data_set.py
@@ -13,16 +13,18 @@ JAN = 1
 FIRST = 1
 DEC = 12
 THIRTY_FIRST = 31
+WEEK = 7
 # Saved data will generally go to the end of previous year, so default for start_date
 # for fetched data is beginning of this year
 BEGINNING_OF_YEAR = date(TODAY.year, JAN, FIRST)
 END_OF_YEAR = date(TODAY.year, DEC, THIRTY_FIRST)
 MODULE_SEPARATOR = "."
-# We make start of week the dividing line between past & future rounds,
+# We make a week ago the dividing line between past & future rounds,
 # because "past" data sets aren't updated until a few days after a given round is over,
 # meaning we have to keep relying on "future" data sets for past matches
 # if we run the pipeline mid-round
 START_OF_WEEK = TODAY - timedelta(days=TODAY.weekday())
+ONE_WEEK_AGO = TODAY - timedelta(days=WEEK)
 
 DATE_RANGE_TYPE: Dict[str, Dict[str, str]] = {
     "whole_season": {
@@ -33,7 +35,7 @@ DATE_RANGE_TYPE: Dict[str, Dict[str, str]] = {
         "start_date": str(BEGINNING_OF_YEAR),
         "end_date": str(START_OF_WEEK),
     },
-    "future_rounds": {"start_date": str(START_OF_WEEK), "end_date": str(END_OF_YEAR)},
+    "future_rounds": {"start_date": str(ONE_WEEK_AGO), "end_date": str(END_OF_YEAR)},
 }
 
 

--- a/src/augury/nodes/common.py
+++ b/src/augury/nodes/common.py
@@ -62,7 +62,7 @@ def _combine_data_horizontally(*data_frames: Sequence[pd.DataFrame]):
     max_date_data_frame = max(sorted_data_frames, key=lambda df: df["date"].max())
 
     for column in set(joined_data_frame.columns[duplicate_columns]):
-        combined_data_frame.loc[:, column] = combined_data_frame[column].fillna(
+        combined_data_frame.loc[:, [column]] = combined_data_frame[column].fillna(
             max_date_data_frame[column]
         )
 


### PR DESCRIPTION
Setting the filter at the beginning of the week has caused errors,
because rounds aren't lasting full weeks at the moment, so there
are missing matches for the current round in the fixture data set.

We leave the filter for past matches at the beginning of the
current week to make sure we don't accidentally replace valid
match data with older fixture data. Deduplication in the
combine_data node should handle any overlap.