### PR TITLE
Add fsspec dependency for kedro DataSet functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ tensorflow==2.3.0
 # Kedro packages
 kedro==0.16.4
 gcsfs # Needed to access Google Cloud Storage files
+fsspec==0.8.0 # Needed for DataSet functionality
 
 # Testing/Linting
 mypy>=0.70 # Need mypy due to references to mypy_extensions in production code


### PR DESCRIPTION
I was getting errors in CI for dependabot PRs, and I'm not sure
why this package is suddenly necessary since I updated kedro
about a month ago, but it seems to fix the issue.