### PR TITLE
Separate Brisbane team into Lions and Bears

### DIFF
--- a/src/augury/settings.py
+++ b/src/augury/settings.py
@@ -55,12 +55,10 @@ TEAM_TRANSLATIONS = {
     "Power": "Port Adelaide",
     "Saints": "St Kilda",
     "Eagles": "West Coast",
-    "Lions": "Brisbane",
+    "Lions": "Brisbane Lions",
     "Cats": "Geelong",
     "Hawks": "Hawthorn",
     "Adelaide Crows": "Adelaide",
-    "Brisbane Lions": "Brisbane",
-    "Brisbane Bears": "Brisbane",
     "Gold Coast Suns": "Gold Coast",
     "Geelong Cats": "Geelong",
     "West Coast Eagles": "West Coast",
@@ -221,7 +219,8 @@ CITIES: Dict[str, Dict[str, Union[str, float]]] = {
 
 TEAM_CITIES = {
     "Adelaide": "Adelaide",
-    "Brisbane": "Brisbane",
+    "Brisbane Lions": "Brisbane",
+    "Brisbane Bears": "Brisbane",
     "Carlton": "Melbourne",
     "Collingwood": "Melbourne",
     "Essendon": "Melbourne",


### PR DESCRIPTION
From what I've read, the general feeling is that these are two
different teams and should be treated as such. I combined them
into "Brisbane" for the sake of simplicity, but it makes more
sense to keep them separate.