### PR TITLE
Fix test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,10 @@ script:
   # Integration tests
   # Using pytest, because coverage.py doesn't play nice with the kedro CLI
   - docker-compose -f docker-compose.ci.yml run data_science coverage run --append -m pytest --no-cov -n auto --dist=loadfile src/tests/integration
-after_script:
+  # Code coverage
+  # Running code coverage commands in scripts instead of after_script,
+  # because after_script silently fails, and I don't check codeclimate often enough
+  # to catch problems early.
   - docker-compose -f docker-compose.ci.yml run data_science coverage xml
   - ./cc-test-reporter format-coverage -t coverage.py
   - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
   # Running code coverage commands in scripts instead of after_script,
   # because after_script silently fails, and I don't check codeclimate often enough
   # to catch problems early.
-  - docker-compose -f docker-compose.ci.yml run data_science coverage xml
+  - docker-compose -f docker-compose.ci.yml run data_science coverage xml -i
   - ./cc-test-reporter format-coverage -t coverage.py
   - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     DOCKER_COMPOSE_VERSION: 1.25.5
     GOOGLE_APPLICATION_CREDENTIALS: .gcloud/keyfile.json
-    CC_TEST_REPORTER_ID: 3c6e7d3ecb1089284ed54da495ee9062362337415223df4c122dc68b575dd708
+    CC_TEST_REPORTER_ID: bc52d889596333356007dd578d7a33f4a69a2c134db9afa2b3d1700ae5455fa9
 install:
   # Install docker-compose
   - sudo rm /usr/local/bin/docker-compose

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -8,12 +8,6 @@ services:
       - ./:/app
     ports:
       - "8008:8008"
-    deploy:
-      resources:
-        limits:
-          # We set the memory limit to the max allowed for Google Cloud Run
-          # to try to catch potential crashes in CI rather than prod
-          memory: 2048M
     depends_on:
       - afl_data
     environment:


### PR DESCRIPTION
When I moved uploading test coverage to `script` in `tipresias`, I neglected to do the same in `augury`, which means I didn't notice that coverage reports weren't getting uploaded. The source of the problem seems to be the `deploy` key in `docker-compose.ci.yml`, which raises an error.