### PR TITLE
Fix flaky test for date filter

### DIFF
--- a/src/augury/nodes/base.py
+++ b/src/augury/nodes/base.py
@@ -25,14 +25,14 @@ EARLIEST_NZ_START_TIME: ReplaceKwargs = {"hour": 13, "minute": 10}
 def _localize_dates(row: pd.Series) -> datetime:
     # Defaulting to Melbourne time, when the datetime isn't location specific,
     # because the AFL has a pro-Melbourne bias, so why shouldn't we?
-    venue_timezone = (
+    venue_timezone_label = (
         VENUE_TIMEZONES.get(row["venue"])
         if "venue" in row.index
         else "Australia/Melbourne"
     )
 
     assert isinstance(
-        venue_timezone, str
+        venue_timezone_label, str
     ), f"Could not find timezone for {row['venue']}"
 
     match_date: datetime = parser.parse(row["date"])
@@ -55,7 +55,7 @@ def _localize_dates(row: pd.Series) -> datetime:
         else match_date
     )
 
-    return match_datetime.replace(tzinfo=pytz.timezone(venue_timezone))
+    return match_datetime.replace(tzinfo=pytz.timezone(venue_timezone_label))
 
 
 def _format_time(unformatted_time: str):

--- a/src/augury/nodes/common.py
+++ b/src/augury/nodes/common.py
@@ -3,12 +3,13 @@
 from typing import Sequence, List, Dict, Any, cast, Callable, Optional, Union
 from functools import reduce, partial, update_wrapper
 import re
-from datetime import datetime
+from datetime import timezone
 
 import pandas as pd
 import numpy as np
+from dateutil import parser
 
-from augury.settings import MELBOURNE_TIMEZONE, INDEX_COLS
+from augury.settings import INDEX_COLS
 from .base import _validate_required_columns, _validate_no_dodgy_zeros
 
 
@@ -134,12 +135,12 @@ def _filter_by_date(
     REQUIRED_COLS = {"date"}
     _validate_required_columns(REQUIRED_COLS, data_frame.columns)
 
-    start_datetime = datetime.strptime(  # pylint: disable=unused-variable
-        start_date, "%Y-%m-%d"
-    ).replace(tzinfo=MELBOURNE_TIMEZONE)
-    end_datetime = datetime.strptime(  # pylint: disable=unused-variable
-        end_date, "%Y-%m-%d"
-    ).replace(hour=11, minute=59, second=59, tzinfo=MELBOURNE_TIMEZONE)
+    start_datetime = parser.parse(  # pylint: disable=unused-variable
+        start_date
+    ).replace(tzinfo=timezone.utc)
+    end_datetime = parser.parse(end_date).replace(  # pylint: disable=unused-variable
+        hour=11, minute=59, second=59, tzinfo=timezone.utc
+    )
 
     return data_frame.query("date >= @start_datetime & date <= @end_datetime")
 

--- a/src/augury/nodes/player.py
+++ b/src/augury/nodes/player.py
@@ -6,10 +6,14 @@ from datetime import datetime, timedelta
 import re
 
 import pandas as pd
-import pytz
 
 from augury.nodes.feature_calculation import rolling_rate_filled_by_expanding_rate
-from augury.settings import TEAM_TRANSLATIONS, AVG_SEASON_LENGTH, INDEX_COLS
+from augury.settings import (
+    TEAM_TRANSLATIONS,
+    AVG_SEASON_LENGTH,
+    INDEX_COLS,
+    MELBOURNE_TIMEZONE,
+)
 from .base import (
     _parse_dates,
     _filter_out_dodgy_data,
@@ -184,7 +188,7 @@ def clean_roster_data(
     # As such, filtering out matches that were played before this week
     # should be sufficient without risking weird results due to timezones
     # if you decide to run the pipeline mid-round.
-    start_of_today = datetime.now(tz=pytz.timezone("Australia/Melbourne"))
+    start_of_today = datetime.now(tz=MELBOURNE_TIMEZONE)
     # We filter from start of week, because past match player data
     # usually isn't available until a few days after a round ends.
     start_of_week = start_of_today - timedelta(  # pylint: disable=unused-variable


### PR DESCRIPTION
Two things were contributing to the flakiness. One, the filter
used Melbourne time for the timezone, but imported data gets
converted to UTC. Two, the end date filter that was used to check
the results was for the beginning of the day instead of the end.
These two oversights meant that match dates toward the edge of
the filter range could be erroneously included/excluded from the
filtered data set.