### PR TITLE
Remove mystery CLI flags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         # Using pytest, because coverage.py doesn't play nice with the kedro CLI
         run: |
           docker-compose -f docker-compose.ci.yml run data_science \
-            coverage run --append -m pytest --no-cov -n auto --dist=loadfile src/tests/integration
+            coverage run --append -m pytest src/tests/integration
       - name: Upload test coverage report
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |


### PR DESCRIPTION
I think I copy/pasted this from CodeClimate, because I can't
find any reference to half these flags in the documentation
for Pytest, Coverage.py, or the plugin that combines them.
I also removed parrallel test running, because the tests only
take 30 seconds.