### PR TITLE
Pull afl_data image during setup instead of test run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           docker pull cfranklin11/tipresias_data_science:latest
           docker pull cfranklin11/tipresias_afl_data:latest
           docker build --cache-from cfranklin11/tipresias_data_science:latest -t cfranklin11/tipresias_data_science:latest -f Dockerfile.local .
+          docker-compose
       - run: mkdir .gcloud
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build image
         run: |
           docker pull cfranklin11/tipresias_data_science:latest
+          docker pull cfranklin11/tipresias_afl_data:latest
           docker build --cache-from cfranklin11/tipresias_data_science:latest -t cfranklin11/tipresias_data_science:latest -f Dockerfile.local .
       - run: mkdir .gcloud
       - name: Set up Google Cloud SDK


### PR DESCRIPTION
I'm not sure if this contributed to docker-compose hanging in
CI, but it makes sense to pull the image beforehand anyway, and
CI passed after I made the change.

Update: still hanging, but calling `docker-compose` by itself
before running any commands seems to work.