### PR TITLE
Use haveged to add entropy to avoid docker-compose bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           docker pull cfranklin11/tipresias_data_science:latest
           docker pull cfranklin11/tipresias_afl_data:latest
           docker build --cache-from cfranklin11/tipresias_data_science:latest -t cfranklin11/tipresias_data_science:latest -f Dockerfile.local .
-          docker-compose
       - run: mkdir .gcloud
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
       GOOGLE_APPLICATION_CREDENTIALS: .gcloud/keyfile.json
     steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get -y install haveged && sudo systemctl start haveged
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Set up code coverage monitoring


### PR DESCRIPTION
According to some GitHub issues I found, docker-compose can hang
if there isn't enough entropy on a server. Given the flakiness
of my recent builds, I suspect that's the problem I'm having.
The suggested solution is to use haveged to generate entropy,
which seems to work.