### PR TITLE
Replace StackingEstimator ensemble with Ridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 Untitled.ipynb
+.Trash-*
 
 # IPython
 .ipython/profile_default/history.sqlite

--- a/notebooks/2.0-trial-different-base-models.ipynb
+++ b/notebooks/2.0-trial-different-base-models.ipynb
@@ -1,0 +1,1872 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "crazy-transsexual",
+   "metadata": {},
+   "source": [
+    "## Trial Different Base Models\n",
+    "\n",
+    "With the removal of the time-series model from the ensemble, we're down to just an `ExtraTreesRegressor` and Elo model feeding into an `ExtraTreesRegressor` meta-estimator. I suspect that adding a few more models to the ensemble would improve overall performance a bit, assuming that the new base estimators have decent performance (~70% mean accuracy across CV folds)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aware-aquarium",
+   "metadata": {},
+   "source": [
+    "## Code Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "viral-tourist",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T08:29:15.265703Z",
+     "start_time": "2021-02-15T08:29:15.208469Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "outside-network",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T20:38:03.179633Z",
+     "start_time": "2021-02-15T20:38:02.802867Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%autoreload 2\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from mlxtend.regressor import StackingRegressor\n",
+    "from xgboost import XGBRegressor\n",
+    "from catboost import CatBoostRegressor\n",
+    "\n",
+    "from sklearn.experimental import enable_hist_gradient_boosting\n",
+    "from sklearn.metrics import mean_absolute_error\n",
+    "from sklearn.base import clone\n",
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.linear_model import Ridge, Lasso\n",
+    "from sklearn.svm import LinearSVR, SVR\n",
+    "from sklearn.ensemble import (\n",
+    "    GradientBoostingRegressor,\n",
+    "    AdaBoostRegressor,\n",
+    "    ExtraTreesRegressor,\n",
+    "    HistGradientBoostingRegressor,\n",
+    "    VotingRegressor,\n",
+    ")\n",
+    "from sklearn.neighbors import KNeighborsRegressor\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "\n",
+    "from augury.ml_estimators import StackingEstimator\n",
+    "from augury.ml_estimators.stacking_estimator import ELO_PIPELINE, META_PIPELINE\n",
+    "from augury.ml_estimators.base_ml_estimator import BASE_ML_PIPELINE\n",
+    "from augury.ml_data import MLData\n",
+    "from augury.settings import CV_YEAR_RANGE, SEED\n",
+    "from augury.model_tracking import score_model, graph_cv_model_performance\n",
+    "from augury.sklearn.preprocessing import DataFrameConverter\n",
+    "\n",
+    "np.random.seed(SEED)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "respected-watch",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T08:29:50.382732Z",
+     "start_time": "2021-02-15T08:29:25.491702Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-15 08:29:25,794 - kedro.io.data_catalog - INFO - Loading data from `full_data` (JSONDataSet)...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>team</th>\n",
+       "      <th>oppo_team</th>\n",
+       "      <th>round_type</th>\n",
+       "      <th>venue</th>\n",
+       "      <th>prev_match_oppo_team</th>\n",
+       "      <th>oppo_prev_match_oppo_team</th>\n",
+       "      <th>date</th>\n",
+       "      <th>team_goals</th>\n",
+       "      <th>team_behinds</th>\n",
+       "      <th>score</th>\n",
+       "      <th>...</th>\n",
+       "      <th>oppo_rolling_prev_match_time_on_ground_skew</th>\n",
+       "      <th>oppo_rolling_prev_match_time_on_ground_std</th>\n",
+       "      <th>oppo_last_year_brownlow_votes_sum</th>\n",
+       "      <th>oppo_last_year_brownlow_votes_max</th>\n",
+       "      <th>oppo_last_year_brownlow_votes_min</th>\n",
+       "      <th>oppo_last_year_brownlow_votes_skew</th>\n",
+       "      <th>oppo_last_year_brownlow_votes_std</th>\n",
+       "      <th>oppo_cum_matches_played</th>\n",
+       "      <th>oppo_rolling_prev_match_goals_plus_rolling_prev_match_behinds</th>\n",
+       "      <th>oppo_rolling_prev_match_goals_divided_by_rolling_prev_match_goals_plus_rolling_prev_match_behinds</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">Adelaide</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">1991</th>\n",
+       "      <th>1</th>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>Hawthorn</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Football Park</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Melbourne</td>\n",
+       "      <td>1991-03-22 03:56:00+00:00</td>\n",
+       "      <td>24</td>\n",
+       "      <td>11</td>\n",
+       "      <td>155</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>72</td>\n",
+       "      <td>15</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.565197</td>\n",
+       "      <td>4.070433</td>\n",
+       "      <td>80</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>Carlton</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Football Park</td>\n",
+       "      <td>Hawthorn</td>\n",
+       "      <td>Fitzroy</td>\n",
+       "      <td>1991-03-31 03:56:00+00:00</td>\n",
+       "      <td>12</td>\n",
+       "      <td>9</td>\n",
+       "      <td>81</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>51</td>\n",
+       "      <td>16</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.449132</td>\n",
+       "      <td>3.913203</td>\n",
+       "      <td>60</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>Sydney</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>S.C.G.</td>\n",
+       "      <td>Carlton</td>\n",
+       "      <td>Hawthorn</td>\n",
+       "      <td>1991-04-07 03:05:00+00:00</td>\n",
+       "      <td>19</td>\n",
+       "      <td>18</td>\n",
+       "      <td>132</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>33</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.403576</td>\n",
+       "      <td>2.433862</td>\n",
+       "      <td>92</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>Essendon</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Windy Hill</td>\n",
+       "      <td>Sydney</td>\n",
+       "      <td>North Melbourne</td>\n",
+       "      <td>1991-04-13 03:30:00+00:00</td>\n",
+       "      <td>6</td>\n",
+       "      <td>11</td>\n",
+       "      <td>47</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>71</td>\n",
+       "      <td>13</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.262708</td>\n",
+       "      <td>4.524495</td>\n",
+       "      <td>69</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>West Coast</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Subiaco</td>\n",
+       "      <td>Essendon</td>\n",
+       "      <td>North Melbourne</td>\n",
+       "      <td>1991-04-21 05:27:00+00:00</td>\n",
+       "      <td>9</td>\n",
+       "      <td>11</td>\n",
+       "      <td>65</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>48</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.913203</td>\n",
+       "      <td>3.218368</td>\n",
+       "      <td>48</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"5\" valign=\"top\">Western Bulldogs</th>\n",
+       "      <th rowspan=\"5\" valign=\"top\">2021</th>\n",
+       "      <th>19</th>\n",
+       "      <td>Western Bulldogs</td>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Eureka Stadium</td>\n",
+       "      <td>Gold Coast</td>\n",
+       "      <td>West Coast</td>\n",
+       "      <td>2021-07-24 02:20:00+00:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>Western Bulldogs</td>\n",
+       "      <td>Melbourne</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>M.C.G.</td>\n",
+       "      <td>Adelaide</td>\n",
+       "      <td>Gold Coast</td>\n",
+       "      <td>2021-07-31 02:20:00+00:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>Western Bulldogs</td>\n",
+       "      <td>Essendon</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Docklands</td>\n",
+       "      <td>Melbourne</td>\n",
+       "      <td>Sydney</td>\n",
+       "      <td>2021-08-07 02:20:00+00:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>Western Bulldogs</td>\n",
+       "      <td>Hawthorn</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>York Park</td>\n",
+       "      <td>Essendon</td>\n",
+       "      <td>Collingwood</td>\n",
+       "      <td>2021-08-14 02:11:00+00:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>Western Bulldogs</td>\n",
+       "      <td>Port Adelaide</td>\n",
+       "      <td>Regular</td>\n",
+       "      <td>Docklands</td>\n",
+       "      <td>Hawthorn</td>\n",
+       "      <td>Carlton</td>\n",
+       "      <td>2021-08-21 02:20:00+00:00</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>31584 rows × 284 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      team      oppo_team round_type  \\\n",
+       "Adelaide         1991 1           Adelaide       Hawthorn    Regular   \n",
+       "                      2           Adelaide        Carlton    Regular   \n",
+       "                      3           Adelaide         Sydney    Regular   \n",
+       "                      4           Adelaide       Essendon    Regular   \n",
+       "                      5           Adelaide     West Coast    Regular   \n",
+       "...                                    ...            ...        ...   \n",
+       "Western Bulldogs 2021 19  Western Bulldogs       Adelaide    Regular   \n",
+       "                      20  Western Bulldogs      Melbourne    Regular   \n",
+       "                      21  Western Bulldogs       Essendon    Regular   \n",
+       "                      22  Western Bulldogs       Hawthorn    Regular   \n",
+       "                      23  Western Bulldogs  Port Adelaide    Regular   \n",
+       "\n",
+       "                                   venue prev_match_oppo_team  \\\n",
+       "Adelaide         1991 1    Football Park                    0   \n",
+       "                      2    Football Park             Hawthorn   \n",
+       "                      3           S.C.G.              Carlton   \n",
+       "                      4       Windy Hill               Sydney   \n",
+       "                      5          Subiaco             Essendon   \n",
+       "...                                  ...                  ...   \n",
+       "Western Bulldogs 2021 19  Eureka Stadium           Gold Coast   \n",
+       "                      20          M.C.G.             Adelaide   \n",
+       "                      21       Docklands            Melbourne   \n",
+       "                      22       York Park             Essendon   \n",
+       "                      23       Docklands             Hawthorn   \n",
+       "\n",
+       "                         oppo_prev_match_oppo_team                      date  \\\n",
+       "Adelaide         1991 1                  Melbourne 1991-03-22 03:56:00+00:00   \n",
+       "                      2                    Fitzroy 1991-03-31 03:56:00+00:00   \n",
+       "                      3                   Hawthorn 1991-04-07 03:05:00+00:00   \n",
+       "                      4            North Melbourne 1991-04-13 03:30:00+00:00   \n",
+       "                      5            North Melbourne 1991-04-21 05:27:00+00:00   \n",
+       "...                                            ...                       ...   \n",
+       "Western Bulldogs 2021 19                West Coast 2021-07-24 02:20:00+00:00   \n",
+       "                      20                Gold Coast 2021-07-31 02:20:00+00:00   \n",
+       "                      21                    Sydney 2021-08-07 02:20:00+00:00   \n",
+       "                      22               Collingwood 2021-08-14 02:11:00+00:00   \n",
+       "                      23                   Carlton 2021-08-21 02:20:00+00:00   \n",
+       "\n",
+       "                          team_goals  team_behinds  score  ...  \\\n",
+       "Adelaide         1991 1           24            11    155  ...   \n",
+       "                      2           12             9     81  ...   \n",
+       "                      3           19            18    132  ...   \n",
+       "                      4            6            11     47  ...   \n",
+       "                      5            9            11     65  ...   \n",
+       "...                              ...           ...    ...  ...   \n",
+       "Western Bulldogs 2021 19           0             0      0  ...   \n",
+       "                      20           0             0      0  ...   \n",
+       "                      21           0             0      0  ...   \n",
+       "                      22           0             0      0  ...   \n",
+       "                      23           0             0      0  ...   \n",
+       "\n",
+       "                          oppo_rolling_prev_match_time_on_ground_skew  \\\n",
+       "Adelaide         1991 1                                           0.0   \n",
+       "                      2                                           0.0   \n",
+       "                      3                                           0.0   \n",
+       "                      4                                           0.0   \n",
+       "                      5                                           0.0   \n",
+       "...                                                               ...   \n",
+       "Western Bulldogs 2021 19                                          0.0   \n",
+       "                      20                                          0.0   \n",
+       "                      21                                          0.0   \n",
+       "                      22                                          0.0   \n",
+       "                      23                                          0.0   \n",
+       "\n",
+       "                          oppo_rolling_prev_match_time_on_ground_std  \\\n",
+       "Adelaide         1991 1                                          0.0   \n",
+       "                      2                                          0.0   \n",
+       "                      3                                          0.0   \n",
+       "                      4                                          0.0   \n",
+       "                      5                                          0.0   \n",
+       "...                                                              ...   \n",
+       "Western Bulldogs 2021 19                                         0.0   \n",
+       "                      20                                         0.0   \n",
+       "                      21                                         0.0   \n",
+       "                      22                                         0.0   \n",
+       "                      23                                         0.0   \n",
+       "\n",
+       "                          oppo_last_year_brownlow_votes_sum  \\\n",
+       "Adelaide         1991 1                                  72   \n",
+       "                      2                                  51   \n",
+       "                      3                                  33   \n",
+       "                      4                                  71   \n",
+       "                      5                                  48   \n",
+       "...                                                     ...   \n",
+       "Western Bulldogs 2021 19                                  0   \n",
+       "                      20                                  0   \n",
+       "                      21                                  0   \n",
+       "                      22                                  0   \n",
+       "                      23                                  0   \n",
+       "\n",
+       "                          oppo_last_year_brownlow_votes_max  \\\n",
+       "Adelaide         1991 1                                  15   \n",
+       "                      2                                  16   \n",
+       "                      3                                   7   \n",
+       "                      4                                  13   \n",
+       "                      5                                   9   \n",
+       "...                                                     ...   \n",
+       "Western Bulldogs 2021 19                                  0   \n",
+       "                      20                                  0   \n",
+       "                      21                                  0   \n",
+       "                      22                                  0   \n",
+       "                      23                                  0   \n",
+       "\n",
+       "                          oppo_last_year_brownlow_votes_min  \\\n",
+       "Adelaide         1991 1                                   0   \n",
+       "                      2                                   0   \n",
+       "                      3                                   0   \n",
+       "                      4                                   0   \n",
+       "                      5                                   0   \n",
+       "...                                                     ...   \n",
+       "Western Bulldogs 2021 19                                  0   \n",
+       "                      20                                  0   \n",
+       "                      21                                  0   \n",
+       "                      22                                  0   \n",
+       "                      23                                  0   \n",
+       "\n",
+       "                          oppo_last_year_brownlow_votes_skew  \\\n",
+       "Adelaide         1991 1                             1.565197   \n",
+       "                      2                             2.449132   \n",
+       "                      3                             1.403576   \n",
+       "                      4                             1.262708   \n",
+       "                      5                             0.913203   \n",
+       "...                                                      ...   \n",
+       "Western Bulldogs 2021 19                            0.000000   \n",
+       "                      20                            0.000000   \n",
+       "                      21                            0.000000   \n",
+       "                      22                            0.000000   \n",
+       "                      23                            0.000000   \n",
+       "\n",
+       "                          oppo_last_year_brownlow_votes_std  \\\n",
+       "Adelaide         1991 1                            4.070433   \n",
+       "                      2                            3.913203   \n",
+       "                      3                            2.433862   \n",
+       "                      4                            4.524495   \n",
+       "                      5                            3.218368   \n",
+       "...                                                     ...   \n",
+       "Western Bulldogs 2021 19                           0.000000   \n",
+       "                      20                           0.000000   \n",
+       "                      21                           0.000000   \n",
+       "                      22                           0.000000   \n",
+       "                      23                           0.000000   \n",
+       "\n",
+       "                          oppo_cum_matches_played  \\\n",
+       "Adelaide         1991 1                        80   \n",
+       "                      2                        60   \n",
+       "                      3                        92   \n",
+       "                      4                        69   \n",
+       "                      5                        48   \n",
+       "...                                           ...   \n",
+       "Western Bulldogs 2021 19                        0   \n",
+       "                      20                        0   \n",
+       "                      21                        0   \n",
+       "                      22                        0   \n",
+       "                      23                        0   \n",
+       "\n",
+       "                          oppo_rolling_prev_match_goals_plus_rolling_prev_match_behinds  \\\n",
+       "Adelaide         1991 1                                                   1               \n",
+       "                      2                                                   1               \n",
+       "                      3                                                   1               \n",
+       "                      4                                                   1               \n",
+       "                      5                                                   1               \n",
+       "...                                                                     ...               \n",
+       "Western Bulldogs 2021 19                                                  0               \n",
+       "                      20                                                  0               \n",
+       "                      21                                                  0               \n",
+       "                      22                                                  0               \n",
+       "                      23                                                  0               \n",
+       "\n",
+       "                          oppo_rolling_prev_match_goals_divided_by_rolling_prev_match_goals_plus_rolling_prev_match_behinds  \n",
+       "Adelaide         1991 1                                                   0                                                  \n",
+       "                      2                                                   0                                                  \n",
+       "                      3                                                   0                                                  \n",
+       "                      4                                                   0                                                  \n",
+       "                      5                                                   0                                                  \n",
+       "...                                                                     ...                                                  \n",
+       "Western Bulldogs 2021 19                                                  0                                                  \n",
+       "                      20                                                  0                                                  \n",
+       "                      21                                                  0                                                  \n",
+       "                      22                                                  0                                                  \n",
+       "                      23                                                  0                                                  \n",
+       "\n",
+       "[31584 rows x 284 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = MLData(train_year_range=(max(CV_YEAR_RANGE),))\n",
+    "data.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "liable-brown",
+   "metadata": {},
+   "source": [
+    "## Try different estimators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "solar-heaven",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-14T21:55:49.293435Z",
+     "start_time": "2021-02-14T21:28:29.431400Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   14.0s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  3.0min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  1.3min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  2.0min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  8.3min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  3.1min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   17.0s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   13.8s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   14.7s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   15.3s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   59.4s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  7.3min finished\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'fit_time': array([1.27853966, 1.33495903, 1.18946385, 1.12688327, 1.043823  ]),\n",
+       "  'score_time': array([0.32906103, 0.33308363, 0.42092371, 0.48012614, 0.28849435]),\n",
+       "  'test_neg_mean_absolute_error': array([-37.91643124, -37.86807506, -32.15199695, -33.0790819 ,\n",
+       "         -29.98658654]),\n",
+       "  'test_match_accuracy': array([0.69902913, 0.71497585, 0.647343  , 0.71497585, 0.64251208])},\n",
+       " {'fit_time': array([158.77840376, 169.34427738, 171.12495661, 170.36221123,\n",
+       "          22.02716303]),\n",
+       "  'score_time': array([0.36904788, 0.37150359, 0.21451402, 0.17691302, 0.07850599]),\n",
+       "  'test_neg_mean_absolute_error': array([-31.0534369 , -30.91602169, -31.01615917, -27.43429879,\n",
+       "         -28.30442699]),\n",
+       "  'test_match_accuracy': array([0.72815534, 0.69082126, 0.63285024, 0.71980676, 0.62318841])},\n",
+       " {'fit_time': array([51.91288352, 57.30967569, 57.77953339, 58.67547083, 27.51634789]),\n",
+       "  'score_time': array([0.50475597, 0.20077229, 0.16583347, 0.12093234, 0.12364435]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.176734  , -28.84481209, -28.93114941, -26.46483423,\n",
+       "         -27.05634126]),\n",
+       "  'test_match_accuracy': array([0.73300971, 0.7294686 , 0.67149758, 0.72463768, 0.61835749])},\n",
+       " {'fit_time': array([61.80264258, 66.40242434, 69.1068058 , 70.3306253 , 58.19737315]),\n",
+       "  'score_time': array([0.13711476, 0.14430332, 0.10374284, 0.22065067, 0.09719205]),\n",
+       "  'test_neg_mean_absolute_error': array([-29.88038367, -28.63451279, -29.19924355, -26.56050117,\n",
+       "         -27.8120996 ]),\n",
+       "  'test_match_accuracy': array([0.72815534, 0.71980676, 0.65700483, 0.70531401, 0.63768116])},\n",
+       " {'fit_time': array([404.05921221, 495.39116907, 465.44542789, 487.06603813,\n",
+       "          89.19651532]),\n",
+       "  'score_time': array([3.28610897, 0.32873058, 4.94779253, 0.52287292, 0.07983589]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.10352859, -28.36592373, -29.14244876, -26.47648313,\n",
+       "         -28.1075948 ]),\n",
+       "  'test_match_accuracy': array([0.72330097, 0.73429952, 0.65217391, 0.70531401, 0.61352657])},\n",
+       " {'fit_time': array([ 90.50234866,  96.19334579, 102.57974219, 102.67025661,\n",
+       "          93.26339197]),\n",
+       "  'score_time': array([0.18008137, 0.16772389, 0.15664816, 0.15095949, 0.14442158]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.37871359, -29.29932367, -28.31292271, -26.45342995,\n",
+       "         -27.97816425]),\n",
+       "  'test_match_accuracy': array([0.72815534, 0.72463768, 0.66666667, 0.71980676, 0.63768116])},\n",
+       " {'fit_time': array([8.27726507, 8.42700458, 8.60136819, 8.70935416, 8.19957328]),\n",
+       "  'score_time': array([0.12384653, 0.15207124, 0.09171057, 0.07711387, 0.08117795]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.14596958, -29.7807293 , -29.20561754, -26.65392595,\n",
+       "         -26.86784369]),\n",
+       "  'test_match_accuracy': array([0.71359223, 0.72463768, 0.66666667, 0.7294686 , 0.64251208])},\n",
+       " {'fit_time': array([6.59053135, 6.85045886, 6.78962922, 7.19603825, 6.82798338]),\n",
+       "  'score_time': array([0.07968378, 0.09323335, 0.0859251 , 0.07674098, 0.07748032]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.17730519, -30.01412265, -29.19379267, -26.50160027,\n",
+       "         -26.94477755]),\n",
+       "  'test_match_accuracy': array([0.73300971, 0.72463768, 0.6763285 , 0.7294686 , 0.65217391])},\n",
+       " {'fit_time': array([7.22981095, 7.4717958 , 7.61620474, 7.62940526, 6.98483276]),\n",
+       "  'score_time': array([0.12596893, 0.09618855, 0.10082483, 0.07839131, 0.0765686 ]),\n",
+       "  'test_neg_mean_absolute_error': array([-31.24235424, -30.53719117, -29.43654875, -27.35879462,\n",
+       "         -27.59143433]),\n",
+       "  'test_match_accuracy': array([0.67961165, 0.70531401, 0.65217391, 0.70531401, 0.63768116])},\n",
+       " {'fit_time': array([6.72667599, 6.86751461, 7.08073497, 6.91460228, 6.80629396]),\n",
+       "  'score_time': array([0.72512531, 0.85958743, 0.84877777, 0.80374527, 0.69743156]),\n",
+       "  'test_neg_mean_absolute_error': array([-31.88640777, -31.70144928, -32.31642512, -29.87584541,\n",
+       "         -31.21111111]),\n",
+       "  'test_match_accuracy': array([0.69902913, 0.70048309, 0.62801932, 0.68599034, 0.5942029 ])},\n",
+       " {'fit_time': array([30.2199676 , 31.54771161, 33.75838423, 33.76174307, 28.64568448]),\n",
+       "  'score_time': array([0.13423753, 0.12653065, 0.11066198, 0.10626912, 0.094877  ]),\n",
+       "  'test_neg_mean_absolute_error': array([-31.5867908 , -31.41257938, -29.41390915, -27.09487761,\n",
+       "         -28.36092743]),\n",
+       "  'test_match_accuracy': array([0.69902913, 0.66666667, 0.65217391, 0.71014493, 0.60386473])},\n",
+       " {'fit_time': array([241.36165571, 259.87769961, 271.40435219, 275.62632203,\n",
+       "         178.84790945]),\n",
+       "  'score_time': array([9.3654213 , 9.2876029 , 8.06918526, 7.46594405, 6.28602052]),\n",
+       "  'test_neg_mean_absolute_error': array([-31.19778055, -30.82394515, -28.82371962, -26.94972621,\n",
+       "         -27.29902299]),\n",
+       "  'test_match_accuracy': array([0.68932039, 0.71980676, 0.6763285 , 0.71014493, 0.64251208])}]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimators = [\n",
+    "    XGBRegressor(random_state=SEED, verbose=False),\n",
+    "    CatBoostRegressor(random_seed=SEED),\n",
+    "    GradientBoostingRegressor(random_state=SEED),\n",
+    "    HistGradientBoostingRegressor(random_state=SEED),\n",
+    "    ExtraTreesRegressor(random_state=SEED),\n",
+    "    LinearSVR(),\n",
+    "    Ridge(),\n",
+    "    Lasso(),\n",
+    "    KNeighborsRegressor(),\n",
+    "    AdaBoostRegressor(random_state=SEED),\n",
+    "    SVR(kernel='rbf'),\n",
+    "]\n",
+    "estimator_scores = []\n",
+    "\n",
+    "scores = score_model(ELO_PIPELINE, data, n_jobs=-1)\n",
+    "estimator_scores.append(scores)\n",
+    "\n",
+    "for estimator in estimators:\n",
+    "    pipeline = make_pipeline(BASE_ML_PIPELINE, estimator)\n",
+    "    scores = score_model(pipeline, data, n_jobs=-1)\n",
+    "    estimator_scores.append(scores)\n",
+    "\n",
+    "estimator_scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "advanced-biotechnology",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-14T21:55:49.409328Z",
+     "start_time": "2021-02-14T21:55:49.297478Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>fit_time</th>\n",
+       "      <th>match_accuracy</th>\n",
+       "      <th>mae</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>kneighborsregressor</td>\n",
+       "      <td>6.879164</td>\n",
+       "      <td>0.661545</td>\n",
+       "      <td>31.398248</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>adaboostregressor</td>\n",
+       "      <td>31.586698</td>\n",
+       "      <td>0.666376</td>\n",
+       "      <td>29.573817</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>lasso</td>\n",
+       "      <td>7.386410</td>\n",
+       "      <td>0.676019</td>\n",
+       "      <td>29.233265</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>xgbregressor</td>\n",
+       "      <td>138.327402</td>\n",
+       "      <td>0.678964</td>\n",
+       "      <td>29.744869</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>eloregressor</td>\n",
+       "      <td>1.194734</td>\n",
+       "      <td>0.683767</td>\n",
+       "      <td>34.200434</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>histgradientboostingregressor</td>\n",
+       "      <td>388.231673</td>\n",
+       "      <td>0.685723</td>\n",
+       "      <td>28.439196</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>svr</td>\n",
+       "      <td>245.423588</td>\n",
+       "      <td>0.687623</td>\n",
+       "      <td>29.018839</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>gradientboostingregressor</td>\n",
+       "      <td>65.167974</td>\n",
+       "      <td>0.689592</td>\n",
+       "      <td>28.417348</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>linearsvr</td>\n",
+       "      <td>8.442913</td>\n",
+       "      <td>0.695375</td>\n",
+       "      <td>28.530817</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>extratreesregressor</td>\n",
+       "      <td>97.041817</td>\n",
+       "      <td>0.695390</td>\n",
+       "      <td>28.484511</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>catboostregressor</td>\n",
+       "      <td>50.638782</td>\n",
+       "      <td>0.695394</td>\n",
+       "      <td>28.294774</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>ridge</td>\n",
+       "      <td>6.850928</td>\n",
+       "      <td>0.703124</td>\n",
+       "      <td>28.566320</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            model    fit_time  match_accuracy        mae\n",
+       "9             kneighborsregressor    6.879164        0.661545  31.398248\n",
+       "10              adaboostregressor   31.586698        0.666376  29.573817\n",
+       "8                           lasso    7.386410        0.676019  29.233265\n",
+       "1                    xgbregressor  138.327402        0.678964  29.744869\n",
+       "0                    eloregressor    1.194734        0.683767  34.200434\n",
+       "4   histgradientboostingregressor  388.231673        0.685723  28.439196\n",
+       "11                            svr  245.423588        0.687623  29.018839\n",
+       "3       gradientboostingregressor   65.167974        0.689592  28.417348\n",
+       "6                       linearsvr    8.442913        0.695375  28.530817\n",
+       "5             extratreesregressor   97.041817        0.695390  28.484511\n",
+       "2               catboostregressor   50.638782        0.695394  28.294774\n",
+       "7                           ridge    6.850928        0.703124  28.566320"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = []\n",
+    "\n",
+    "for idx, scores in enumerate(estimator_scores):\n",
+    "    model_name = 'eloregressor' if idx == 0 else estimators[idx - 1].__class__.__name__.lower()\n",
+    "    results.append(\n",
+    "        {\n",
+    "            'model': model_name,\n",
+    "            'fit_time': scores['fit_time'].mean(),\n",
+    "            'match_accuracy': scores['test_match_accuracy'].mean(),\n",
+    "            'mae': abs(scores['test_neg_mean_absolute_error'].mean()),\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "results_df = pd.DataFrame(results)\n",
+    "results_df.sort_values('match_accuracy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "surrounded-office",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-14T21:55:50.117809Z",
+     "start_time": "2021-02-14T21:55:49.415140Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-14 21:55:49,596 - matplotlib.legend - WARNING - No handles with labels found to put in legend.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA44AAAJwCAYAAADGGD9JAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABuYUlEQVR4nO3dd5xkVZn/8c+XpEiQNATJqBgwgKJiANOaA6Y1oICua9z9mde0ooI5YRYFE6BiBAVzQAXMuIqKKKLkHAdmyPD8/ri3mZqa6pqegel7e+rzfr361dXn3qp6qrrq1n3qnPOcVBWSJEmSJE1nla4DkCRJkiT1m4mjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZSkHkry3CSV5CHLef2HtNd/7i0amJZZkm2TfDPJhe3/5PNdx6RFRr1XkmzTtr11hrfx+SQrZH2zJG9tY9lmRdy+JM2UiaMkDRk4kawkH5tmn42TXNvu87NZDlFzy+eBBwPvAfYEPtVpNOqdJE+aaZIqSV0xcZSk6V0N7JHkViO27QkEuH52Q9Jc0r52dgUOrar3V9UXqupXXcelpTodWBN4+yzd35OAt0yz7e1tLKfPUiySNJKJoyRN7whgfWD3EdueB3wXuGZWI9Ji0li76zjG2ITmC4ZLbukbTrLOLX2bs3Hbc0E1rq6qzr8Yqqrr21hWyFBYSZopE0dJmt7/AX+iSRJvkuS+wA7A56a7Yjv07BdJFiZZ0F4elYCS5AVJ/pbkmiSnJHkFTbIxat/bJnlPu9817by5w5Jst7wPMsntknwgyR+TXJrk6iR/TfK6JKuO2H+NJK9t978yyfwkxyf576H91k3yjiQntbd5cZLjkjxzYJ+fJTltxH0sMcdscC5akv9K8leaXuHXtNvv2841O7mN64r2eX/yNI970yQfSfKv9rm8IMmPkjyi3f6t9nbWHXHd+7SxvHnM8/p5FvUSvWVg+PND2u2rtc/xXweenyOS3H265yLJM5L8PslVwEenu++B6+6U5GtJzm8f45nt6+X2A/tU+7w9vP3/LACOGtg+o9dykgck+V6S89rHc3aS7ybZZWCfDZJ8MMk/Bx7z75P8z1Iex3rt/odPs/1d7ePYsf17mV7TI25v5BzHJLdO8r4k5yS5KslvkzxymtuY0esxzVD3vdvLNfDz3LZt5BzHNsZDB/63/0zyziS3Gdpv6vp3aref1e5/QpLHLu25kKQpq3UdgCT13GeB/ZNsXlVnt23/AVwAfHvUFZK8FPg48Ddgv7b5ucA3k7yoqg4c2PcVwAeBE4A3ArehSYQuGHG7twV+CWzVxnUisBnwUuA3SXauquUZznYP4Ck0Paz/BFYHHg28G9gOeNFADGsAPwAeAvwQ+AJN8nb39jY+1u63HnAcTYL9deAAYFVgJ+DxwJeXI84prwA2BA4CzgPObNufDNwZ+CpNwrYhzQn54UmeXVVfGngc2wC/oOkRPAQ4HlgL2AX4N+BH7e0/EXgWS85LfD5wI83/YTqfAv5I8/89AphKek5qf38ReHp7XwcAmwL/Bfwqya5V9Yeh23sS8LJ2308Cl4+5b5I8HvgGsBD4NHBKex+PAu5G87+esjPw1PYxHzxwGzN6LSe5U/s4zgM+DJxP89w+CLgn8Ov2ul8Ddmvj/xPNEMy70Lye3jfdY6mqy5IcCeyeZIOquqkHN8kqwLOBP1XVH9vmGb+ml9FhNP+Ho2jeB7en+b+eOmLfmb4e30HzRf6uNEPgp/xyuiCSbA38Frgt8AngHzTP4RuAByZ5+Ije0oOB64D3A2vQvI++mWT7qjptqY9ckqrKH3/88cefgR+aE7CiSeA2pBmO+sZ225rAZcD7278XAD8buO76bdspwLoD7evSnMBeAazXtq1Hc1L/V+A2A/tu0d5GAQ8ZaP8wcBVwz6F4t6ZJIj4/4jE8dwaPd00gI9oPBW4ANhtoe217u+8csf8qA5c/0e73wqXs9zPgtBH7bNNe/60jHtMlwMYjrrPWiLbbAH8H/jrU/t32th41XXw0ie4ZwG9H3OZ84LszeG6XeBxt+yPa9q8MPvc0Sdb1wLEjbuM64C4zfA3fBriQ5guIzZfyP6j259+G9lmW1/LL2tu475iYbtvu84nlfF8+rr3+S4faH962v2o5X9NLvFemef09sm37/NBtPmnqObwZr8fPD19/YNtb29vfZqDti23bY4f2fV/b/vwR1//20GvtPm37u5bn/+GPP/5M3o9DVSVpjKq6GDiSppcFml6M2zJ9T9MjaHquPlJVN/UItZc/AqxN06MFzYnobYCPV9WVA/ueRXNieJMkoelVOQY4O8lGUz80yeev29tbnsd4VVVVez9rtMMJN6LpUVmFpjdqyrOBS1nU+zR4Oze2t7EK8EzgpBroXR3e72Y4pKqW6JGtqoVTl5PcJsmGNM/v0cBd0g45TbIBTe/T96vqB9PFV1U30Pyf75PFh48+jSZ5+szNeAxTwxXfMfXct/d5Ak1v1oOSzBu6zneq6iRm5lHARsAHalFP+U1G/A9OqKofD7Uty2t5fvt79yS3niamq2i+hLnf8LDLGfoBTU/mXkPte9Ek2ze9Z5bxNT1TT2p/L9YzWlXfpEkGGWqf0etxWbXvrycCf6iq7w5tfhdNT/io4dkfHnqt/Y7mi4E7Lk8ckiaPiaMkLd3ngDsmeRDNMNXfVtVfp9l32/b3iSO2TbVtN/T7byP2Hb79eTS9n4+k6Uka/nkEzdDAZZZmrt2bkpxMM+z04vY2D213WX9g9zsCf6uqq8fc5Ebtdf64PPHMwMmjGtMskXJgkvNpkumLaB7Hi9td1mt/34FmDunwUNBRPkPTQ/X8gbbn0/TkHbnMkS+yLc0J/qhE8MSBfQaNfNzTmEoGZvIYp7vtZXktfxn4Mc1w60uSHN3OJ9x66gpVdS3N8Mi7AacmOTHJR5M8fPCGk8xLM/906mdee/2p5PB+SbZv912L5sucH1bV+QO3sSyv6ZnajuZ/Nuq5WuL/uAyvx2U1jyZpX+L/Us0Q3nNZ9H8Z9K8RbRfTHFckaalMHCVp6X4AnE1TLv+hjJ/XtqJMFcv5MU2SOOrnUct52/sDb6MpBvQ84LHt7b2u3b4iPyumqxQ5bg7+lcMNbY/sD2nmkB0MPIOmV/ERwNRcsmV+HFV1JvB94Dltz9UdaeboHVJV1y3r7d1MSzzuvtx2VV1TVY8A7kfT63UDTa/03waLwVTVJ2mGgb6A5vX2NODHSQbnvP6OJvmZ+vndwLZD2t9TvY5PoUmiDmZxXb6mV9jr8Wa6YZr2kYW4JGmYxXEkaSmq6oYkh9AUnriKpkDGdKa+1d8B+MnQtrsO7TP1+85j9p1yIc3cynVHDCm8ufYEjqmqZw42JrnDiH1PBu6c5FZVNd1SJBfRDGe95wzu+xLg3iPal7VK7D3a+9uvqhZbDy/Jfw7tewpNwrrjDG/7QJr5dU+iKe4DN2+YKjT/+1VoCsP8aWjb1P9+VMGVmZrqFduRJoFZHsvyWgagqn5LU7SFJFvS9Hi+naZIzdQ+59IU6/l0W+H0UOBZST7QDp98Ns0cxSlXDVz3hCQn0CTy+9AkkJexZO/vsrymZ2rqf7Y9S/b23WXo72V5PcL0X6CMciHN/NIdhjckWZ+mYNYfl+H2JGlG7HGUpJn5JLAv8OLB+V4j/IhmWNr/y8BaeO3l/0czp+hHA/teBfzXYAn9JFsAewzeaDsn7YvAfZM8bdQdJ9l4WR9U6waGeh3aIYCvHLHvF2mG+b1pxP1nINbDgLsmef50+7VOBtZJs8TJ1PZVprnvpT0GWPJx3I2h+V7tcL7vAY9J8m8MGYoP4DvAOTSVOPcGflFVo4YXL4tvtr/fMHh/bbxPBI6rqgtvxu3/kCaBf3WSzYY3jniMo8z4tdzOHxx2Fk2Ss0G7z20ytFREO490KnHeoG37RVX9eODnF0O3ezBNQag9gIcBXxkxdHpZXtMz9a3292JLhyR5EnCnEffPiBiWeD22FrTbN1haEO376yhgpySPHtr8eppzuyOWuKIk3Uz2OErSDFTVGTTVCZe232VJXkuzhMFv0qzlB01xnTsAL6qq+e2+l7a9Ju8Hftn2at6GZg7UP1jUuzXlf4EHAl9N8lWagjjX0pxEPxb4PYuK+CyLrwMvSvIVmqGwm9DM5bx4xL4fBp4AvCnJfWgSlKtpej/uxKJiKW+iOan/dJp17o6jOYneieazZ2rZgQOBVwNHJPlw+3iexrJ/Pp1E0wv02jY5+TtNz9CLgD+zZK/mf9Msd/C9JAfTPHdr0gy1PI1FQxqnepw/y6Jk+Y3LGNsSqupH7f/wmcD6Sb7NouU4rqapUnpzbv/KNmn/OvCXJFPLccyjGdK8P4sSoeluY8avZZrXwyNpKneeSvO/fgJNb/p72322B36e5AjgLzS90ncBXtJe59gZPrwvtrf5CZokaXiYKizba3pGquoHSY4C9m4TvO/TLMfxovbx3G1g92V9Pf6a5jX5iSTfoamg+5uqmq7X+Y00w16/meQTNP/b3WiGxB7D6OdEkm4WE0dJuoVV1SeSnEvTMzE1TO0E4MltBcbBfT+QZsH1V9HMDTuTJpGcz9Bcyqqan+SBNInW04HdaapJnkWTmH16OUN+Fc3Qt6nbPJMmofsdzUn3YAzXtgnCq2l6fN5Jk+j8g6aI0NR+lya5P80J7lNoelmuoCn689GB/U5te2zeSTMn7WKaoYufZXTRoJHa5O5xNM/d3jTVQP/SXr4nQyfq7f3uDOxDk3TvRZPInNA+9mGfbh/LQpq1CG8Jz6aZg/dc4APtbf8c2Keq/nxzb7yqjmwLOr2RpqDPOjRVSY+lSV5mchszfS1/k2aI5NNpkrSraF4TL2DRsN4zaf6vD6UZ9nsrmrnDBwHvGawsvJSYLkjyfZr1QP9RVb8asduMX9PL6Bk0Q2+fTZO4/Znm9b0HA4njsr4eaXrod6L5IuHfaRLi5zHNcOWqOj3J/WjmkT6HptDOWTTHkLfXkms4StLNloHKzJIkaYR2uOeZwGeqankXj5ckac5yjqMkSUv3EmBVRvdGSpK00nOoqiRJ00jyTGArmqGaP6iq33cckiRJnXCoqiRJ00hSNHM4jwWeV1VndxySJEmdMHGUJEmSJI3lHEdJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGmu1rgPoi4022qi22WabrsOQJEmSpE78/ve/v6iq5o3aZuLY2mabbTj++OO7DkOSJEmSOpHk9Om2OVRVkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWNZVVWSJEmS5rAbb7yRiy66iMsuu4wbbrhh5D6rrroq6623HhtttBGrrLLs/YcmjpIkSZI0h5111lkkYZtttmH11VcnyWLbq4rrrruO888/n7POOoutttpqme/DoaqSJEmSNIctXLiQzTffnDXWWGOJpBEgCWussQabb745CxcuXK77MHGUJEmSpDluJsNPl2eI6k3XXe5rSpIkSZImgomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJGmOq6pbZJ/pmDhKkiRJ0hy2+uqrc9VVVy11v6uuuorVV199ue7DxFGSJEmS5rCNN96Ys88+myuvvHJkr2JVceWVV3L22Wez8cYbL9d9rHZzg5QkSZIkdWfdddcF4JxzzuG6664buc/qq6/OJptsctO+y8rEUZIkSZLmuHXXXXe5k8KZcKiqJEmSJGksE0dJkiRJ0lgmjpIkSZKksWY1cUyyQZIjkixMcnqSPabZ73tJFgz8XJvkz+22jZMcluScJPOT/CLJ/Qau+5AkNw5df+/ZeoySJEmStLKZ7eI4HweuBTYBdgS+k+SEqjpxcKeqeszg30l+Bhzd/rk28DvgVcAFwPPb29mmqha0+5xTVVusqAchSZIkSZNk1nock6wFPBXYp6oWVNVxwJHAnku53jbArsAhAFX1r6rav6rOraobqupAYA3gTiv0AUiSJEnShJrNoarbA9dX1ckDbScAOyzlensBx1bVaaM2JtmRJnE8ZaB54yTnJzk1yQfbpHXUdV+Y5Pgkx1944YUzfRySJEmSNFFmM3FcG7h8qG0+sM5SrrcX8PlRG5KsCxwK7FtV89vmv9EMg90MeBhwb2D/UdevqgOraueq2nnevHkzeAiSJEmSNHlmM3FcAAyvSLkucMV0V0jyIGBT4Osjtq0JHAX8uqreNdVeVedV1V+r6saqOhV4Lc0QWUmSJEnScpjNxPFkYLUkdxxouydw4jT7A+wNHD5Q9AaAJLcCvgmcBbxoKfdbuOyIJEmSJC23WUuoqmohcDiwX5K1kjwQ2J1mqOkS2h7FpzM0TDXJ6jQ9kFcBe1fVjUPbH5pk6zS2BN4NfOuWfjySJEmSNClmuyfupcCaNMtoHAa8pKpOTLJrkgVD+z4JuAz46VD7A4DHA48ELhtYq3HXdvtOwC+Bhe3vPwMvWwGPRZIkSZImQqqq6xh6Yeedd67jjz++6zAkSZIkqRNJfl9VO4/a5tw/SZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkaa7WuA5gLLjzgC12HsELNe8lzug5BkiRJUo/Z4yhJkiRJGmtWE8ckGyQ5IsnCJKcn2WOa/b6XZMHAz7VJ/jywfZskP01yZZK/Jfm3oeu/Msl5SS5P8tkkt1rRj02SJEmSVlaz3eP4ceBaYBPg2cABSXYY3qmqHlNVa0/9AL8Evjawy2HAH4ANgf8Fvp5kHkCSRwGvBx4ObA1sB+y74h6SJEmSJK3cZi1xTLIW8FRgn6paUFXHAUcCey7letsAuwKHtH9vD9wLeEtVXVVV3wD+3N42wN7AZ6rqxKq6FHgb8Nxb/hFJkiRJ0mSYzR7H7YHrq+rkgbYTgCV6HIfsBRxbVae1f+8A/KuqrpjmdnZo/x7ctkmSDZc3cEmSJEmaZLOZOK4NXD7UNh9YZynX2wv4/NDtzB9zO8Pbpy4vcT9JXpjk+CTHX3jhhUsJQ5IkSZIm02wmjguAdYfa1gWuGLEvAEkeBGwKfH0Zbmd4+9TlJe6nqg6sqp2raud58+Yt9QFIkiRJ0iSazcTxZGC1JHccaLsncOKY6+wNHF5VCwbaTgS2SzLYgzh4Oye2fw9uO7+qLl7uyCVJkiRpgs1a4lhVC4HDgf2SrJXkgcDuwKGj9k+yJvB0Fh+mSjtH8o/AW5LcOsmTgXsA32h3OQR4fpK7JlkPeNPwbUiSJEmSZm62l+N4KbAmcAHNkhovqaoTk+yaZMHQvk8CLgN+OuJ2ngnsDFwKvBt4WlVdCFBV3wfe217vDOB04C23+CORJEmSpAmx2mzeWVVdQpMQDrcfS1PUZrDtMJrkctTtnAY8ZMz97A/sv/yRSpIkSZKmzHaPoyRJkiRpjjFxlCRJkiSNZeIoSZIkSRprVuc4auVyxkee1nUIK9RWL/v60nca4QefeewtHEl/POr5312u633q0EfdwpH0y4v2/EHXIUiSJK1Q9jhKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRprta4DkKRJ9bwjHt11CCvU5578/a5DkCRJtxB7HCVJkiRJY5k4SpIkSZLGMnGUJEmSJI3lHEdJUq887oj3dR3CCvWdJ/9P1yFIkrTM7HGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lnMcJUmaAx7/9S92HcIK8+2nPbvrECRJS2GPoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLGc4yhJkuakJ339J12HsEJ982kP7zoESbqJPY6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lirdR2AJEmSbjkvO+LMrkNYoT7y5C27DkGaSPY4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI01qwmjkk2SHJEkoVJTk+yx5h975XkmCQLkpyf5OVt+1Zt2+BPJXl1u/0hSW4c2r73bD1GSZIkSVrZzHZV1Y8D1wKbADsC30lyQlWdOLhTko2A7wOvBL4OrAFsAVBVZwBrD+y7LXAK8I2BmzinqrZYcQ9DkiRJc8n3vnJR1yGsUI95xkZdh6CV3Kz1OCZZC3gqsE9VLaiq44AjgT1H7P4q4AdV9cWquqaqrqiqk6a56b2AY6rqtBUSuCRJkiRNuNkcqro9cH1VnTzQdgKww4h9dwEuSfLLJBckOSrJVsM7JQlN4njw0KaN2+Gtpyb5YJu0LiHJC5Mcn+T4Cy+8cPkelSRJkiSt5GYzcVwbuHyobT6wzoh9twD2Bl4ObAWcChw2Yr8H0Qx7/fpA299ohsFuBjwMuDew/6iAqurAqtq5qnaeN2/ejB+IJEmSJE2S2UwcFwDrDrWtC1wxYt+rgCOq6ndVdTWwL/CAJLcd2m9v4BtVtWCqoarOq6q/VtWNVXUq8FqaIbKSJEmSpOUwm4njycBqSe440HZP4MQR+/4JqIG/a3iHJGsC/86Sw1SHFS47IkmSJEnLbdYSqqpaCBwO7JdkrSQPBHYHDh2x++eAJyfZMcnqwD7AcVU1f2CfJwOXAj8dvGKShybZOo0tgXcD31oBD0mSJEmSJsJs98S9FFgTuIBmzuJLqurEJLsmGRxuejTwRuA77b53AIbXfNwbOLSqhnsjdwJ+CSxsf/8ZeNkKeCySJEmSNBFmdR3HqroEeNKI9mMZWJuxbTsAOGDMbT1qmvb9maYYjiRJkiRp2Tn3T5IkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWKt1HYAkSZKkbpz2ofO6DmGF2eYVm3YdwkrFHkdJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWKt1HYAkSZIk9cX5H/5V1yGsUJu8/P7LdT17HCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGmtGiWOSJyVZdUUHI0mSJEnqn5n2OH4RODvJe5JsvyIDkiRJkiT1y0wTx02BtwAPBk5KclyS5yVZa8WFJkmSJEnqgxkljlV1RVV9qqp2Ae4B/AZ4F3BukoOS7LIig5QkSZIkdWeZi+NU1YnAB4EDgTWAZwDHJvlNknvcwvFJkiRJkjo248QxyepJnp7k+8CpwMOAFwObAFsDJwFfWSFRSpIkSZI6s9pMdkryUeBZQAGHAq+qqr8O7HJVktcD59zyIUqSJEmSujSjxBG4K/DfwOFVde00+1wEPPQWiUqSJEmS1BszShyr6uEz2Od64Oc3OyJJkiRJUq/MaI5jknckefGI9hcnedstH5YkSZIkqS9mWhxnT+API9p/D+x1y4UjSZIkSeqbmSaOGwMXjmi/mKaqqiRJkiRpJTXTxPEMYNcR7bsBZ91y4UiSJEmS+mamVVU/BXwwyRrA0W3bw4F3Ae9ZEYFJkiRJkvphRj2OVfUBmuTxI8DJ7c+HgYOq6r0zvbMkGyQ5IsnCJKcn2WPMvvdKckySBUnOT/LygW2nJbmq3bYgyQ+HrvvKJOcluTzJZ5PcaqYxSpIkSZIWN9OhqlTVG4CNgF3an3lV9fplvL+PA9fSzIt8NnBAkh2Gd0qyEfB9mmR1Q+AOwA+HdntCVa3d/jxy4LqPAl5P0yO6NbAdsO8yxilJkiRJas04cQSoqoVV9bv2Z8GyXDfJWsBTgX2qakFVHQccSVOxddirgB9U1Rer6pqquqKqTprhXe0NfKaqTqyqS4G3Ac9dllglSZIkSYvMOHFM8tAkByb5fpKjB39meBPbA9dX1ckDbScAS/Q40vRoXpLkl0kuSHJUkq2G9vlikguT/DDJPQfad2hvd/A+Nkmy4QzjlCRJkiQNmFHimOS5wPeAdYCH0CzNsT5wL+CvM7yvtYHLh9rmt7c5bAuansOXA1sBpwKHDWx/NrANzVDUnwI/SLLewP3MH7oPRt1PkhcmOT7J8RdeOGq1EUmSJEnSTHscXwP8d1U9C7gOeENV7QR8AZjpkNUFwLpDbesCV4zY9yrgiHZI7NU0cxQfkOS2AFX1i6q6qqqurKp3AZexaLmQ4fuZurzE/VTVgVW1c1XtPG/evBk+DEmSJEmaLDNNHLcDftxevoamVw/gY8x8/uDJwGpJ7jjQdk/gxBH7/gmogb9rxD4MbU97+cT2dgfv4/yquniGcUqSJEmSBsw0cbyYRUM9zwbu1l7eEFhzJjdQVQuBw4H9kqyV5IHA7sChI3b/HPDkJDsmWR3YBziuquYn2SrJA5OskeTWSf6HptrrL9rrHgI8P8ld2+GrbwI+P8PHKUmSJEkaMtPE8VhgasmLrwIfSfI5mnmHP1qG+3spTaJ5QXvdl1TViUl2TXLTkNeqOhp4I/Cddt87AFNrPq4DHABcSpPEPhp4zFSPYlV9H3gvzdzHM4DTgbcsQ4ySJEmSpAGrzXC//wZu3V5+F3A98ECaJPLtM72zqroEeNKI9mNZNPx1qu0AmgRxeN8TgXss5X72B/afaVySJEmSpOktNXFMshrwTOCbAFV1I/CeFRuWJEmSJKkvljpUtaquB94HrL7iw5EkSZIk9c1M5zj+Grj3igxEkiRJktRPM53jeBDw/iRbAb8HFg5urKr/u6UDkyRJkiT1w0wTxy+1v0cVnClg1VsmHEmSJElS38w0cdx2hUYhSZIkSeqtGSWOVXX6ig5EkiRJktRPM0ockzxl3PaqOvyWCUeSJEmS1DczHar69Wnaq/3tHEdJkiRJWknNaDmOqlpl8AdYA7gfcCyw24oMUJIkSZLUrZmu47iYqrq+qn4HvBH4xC0bkiRJkiSpT5YrcRxwGXD7WyAOSZIkSVJPzbQ4zr2Gm4DNgNcBf7ilg5IkSZIk9cdMi+McT1MIJ0Ptvwaed4tGJEmSJEnqlZkmjtsO/X0jcGFVXX0LxyNJkiRJ6pkZJY5VdfqKDkSSJEmS1E8zKo6T5B1JXjyi/cVJ3nbLhyVJkiRJ6ouZVlXdk9FFcH4P7HXLhSNJkiRJ6puZJo4bAxeOaL8Y2OSWC0eSJEmS1DczTRzPAHYd0b4bcNYtF44kSZIkqW9mWlX1U8AHk6wBHN22PRx4F/CeFRGYJEmSJKkfZlpV9QNJNgI+AqzRNl8LfLiq3ruigpMkSZIkdW+mPY5U1RuSvB24a9t0UlUtWDFhSZIkSZL6YkaJY5JNgdWq6izgdwPtWwDXVdX5Kyg+SZIkSVLHZloc5wvAY0a0Pwo49JYLR5IkSZLUNzNNHHcGjhnRfmy7TZIkSZK0kppp4rgacKsR7beepl2SJEmStJKYaeL4G+AlI9r/i4E5j5IkSZKklc9Mq6r+L3B0knuwaB3HhwH3olnPUZIkSZK0kppRj2NV/Rq4P3Aa8JT251/ALsBtVlRwkiRJkqTuLcs6jicAz4abluF4HnAEsDWw6gqJTpIkSZLUuZnOcSTJqkmekuQ7wKnAk4BPAndYQbFJkiRJknpgqT2OSe4E/CewF7AQ+BLN+o17VtVfV2x4kiRJkqSuje1xTHIs8GtgfeDpVbVdVb0JqNkITpIkSZLUvaX1ON4f+DhwYFWdOAvxSJIkSZJ6ZmlzHO9Dk1wel+QPSV6ZZNNZiEuSJEmS1BNjE8eq+kNV/RewGbA/8ETgzPZ6j0uy/ooPUZIkSZLUpZmu43h1VR1aVQ8F7gK8D3glcF6S763IACVJkiRJ3ZrxchxTquqUqno9sCXwdODaWzwqSZIkSVJvLHU5julU1Q3At9ofSZIkSdJKapl7HCVJkiRJk2VWE8ckGyQ5IsnCJKcn2WPMvvdKckySBUnOT/Lytn3jJIclOSfJ/CS/SHK/ges9JMmN7fWmfvaejccnSZIkSSuj5R6qupw+TjMnchNgR+A7SU4YXiMyyUbA92kK8HwdWAPYot28NvA74FXABcDz29vZpqoWtPucU1VbIEmSJEm62WatxzHJWsBTgX2qakFVHQccCew5YvdXAT+oqi9W1TVVdUVVnQRQVf+qqv2r6tyquqGqDqRJLO80W49FkiRJkibJbA5V3R64vqpOHmg7AdhhxL67AJck+WWSC5IclWSrUTeaZEeaxPGUgeaN2+Gtpyb5YJu0jrruC5Mcn+T4Cy+8cLkelCRJkiSt7GYzcVwbuHyobT6wzoh9twD2Bl4ObAWcChw2vFOSdYFDgX2ran7b/DeaYbCbAQ8D7g3sPyqgqjqwqnauqp3nzZu3rI9HkiRJkibCbCaOC4B1h9rWBa4Yse9VwBFV9buquhrYF3hAkttO7ZBkTeAo4NdV9a6p9qo6r6r+WlU3VtWpwGtphshKkiRJkpbDbCaOJwOrJbnjQNs9gRNH7PsnoAb+HrxMklsB3wTOAl60lPstXHZEkiRJkpbbrCVUVbUQOBzYL8laSR4I7E4z1HTY54AnJ9kxyerAPsBxVTW//fvrNL2Se1fVjYNXTPLQJFunsSXwbuBbK/ChSZIkSdJKbbZ74l4KrEmzjMZhwEuq6sQkuyaZWkqDqjoaeCPwnXbfOwBTaz4+AHg88EjgsoG1Gndtt+8E/BJY2P7+M/CyFf7IJEmSJGklNavrOFbVJcCTRrQfS1M8Z7DtAOCAEfv+HMiY+9ifaYrhSJIkSZKWnXP/JEmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFmNXFMskGSI5IsTHJ6kj3G7HuvJMckWZDk/CQvH9i2TZKfJrkyyd+S/NvQdV+Z5Lwklyf5bJJbrcjHJUmSJEkrs9nucfw4cC2wCfBs4IAkOwzvlGQj4PvAp4ANgTsAPxzY5TDgD+22/wW+nmRee91HAa8HHg5sDWwH7LuCHo8kSZIkrfRmLXFMshbwVGCfqlpQVccBRwJ7jtj9VcAPquqLVXVNVV1RVSe1t7M9cC/gLVV1VVV9A/hze9sAewOfqaoTq+pS4G3Ac1fog5MkSZKkldhs9jhuD1xfVScPtJ0ALNHjCOwCXJLkl0kuSHJUkq3abTsA/6qqK6a5nR3avwe3bZJkw1vkUUiSJEnShJnNxHFt4PKhtvnAOiP23YKm5/DlwFbAqTTDU6duZ/6Y2xnePnV5iftJ8sIkxyc5/sILL5zhw5AkSZKkyTKbieMCYN2htnWBK0bsexVwRFX9rqquppmj+IAkt53B7Qxvn7q8xP1U1YFVtXNV7Txv3rxlejCSJEmSNClmM3E8GVgtyR0H2u4JnDhi3z8BNfD34OUTge2SDPYgDt7Oie3fg9vOr6qLlzdwSZIkSZpks5Y4VtVC4HBgvyRrJXkgsDtw6IjdPwc8OcmOSVYH9gGOq6r57RzJPwJvSXLrJE8G7gF8o73uIcDzk9w1yXrAm4DPr8CHJkmSJEkrtdlejuOlwJrABTRzFl9SVScm2TXJgqmdqupo4I3Ad9p97wAMrvn4TGBn4FLg3cDTqurC9rrfB94L/BQ4AzgdeMsKflySJEmStNJabTbvrKouAZ40ov1YmqI2g20HAAdMczunAQ8Zcz/7A/svf6SSJEmSpCmz3eMoSZIkSZpjTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksWY1cUyyQZIjkixMcnqSPabZ761JrkuyYOBnu3bbrkPtC5JUkqe225+b5Iah7Q+ZvUcpSZIkSSuX1Wb5/j4OXAtsAuwIfCfJCVV14oh9v1JVzxlurKpjgbWn/m6TwqOA7w/s9quqetAtF7YkSZIkTa5Z63FMshbwVGCfqlpQVccBRwJ73syb3hv4elUtvLkxSpIkSZKWNJtDVbcHrq+qkwfaTgB2mGb/JyS5JMmJSV4yaoc2GX0acPDQpp2SXJTk5CT7JJntnlVJkiRJWmnMZkK1NnD5UNt8YJ0R+34VOBA4H7gf8I0kl1XVYUP7PQW4CPj5QNsxwN2A02mS0q8A1wPvGr6TJC8EXgiw1VZbLePDkSRJkqTJMJs9jguAdYfa1gWuGN6xqv5aVedU1Q1V9UvgwzQ9i8P2Bg6pqhq47r+q6tSqurGq/gzsN811qaoDq2rnqtp53rx5y/mwJEmSJGnlNpuJ48nAaknuONB2T2BUYZxhBWSwIcmWwEOAQ5b1upIkSZKkmZu1xLEtXnM4sF+StZI8ENgdOHR43yS7J1k/jfsCLwO+NbTbnsAvq+qfQ9d9TJJN2st3BvYZcV1JkiRJ0gzN6jqOwEuBNYELgMOAl1TViVNrMw7s90zgFJphrIcA76mq4QI4e7FkURyAhwN/SrIQ+C5NsvrOW/ZhSJIkSdLkmNVqo1V1CfCkEe2Lrc1YVc+awW3deZr21wCvWf4oJUmSJEmDZrvHUZIkSZI0x5g4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWOZOEqSJEmSxjJxlCRJkiSNZeIoSZIkSRrLxFGSJEmSNJaJoyRJkiRpLBNHSZIkSdJYJo6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGsvEUZIkSZI0lomjJEmSJGksE0dJkiRJ0lgmjpIkSZKksUwcJUmSJEljmThKkiRJksYycZQkSZIkjWXiKEmSJEkay8RRkiRJkjSWiaMkSZIkaSwTR0mSJEnSWCaOkiRJkqSxTBwlSZIkSWPNauKYZIMkRyRZmOT0JHtMs99bk1yXZMHAz3YD26u9jaltnx7YliTvSXJx+/OeJJmNxydJkiRJK6PVZvn+Pg5cC2wC7Ah8J8kJVXXiiH2/UlXPGXNb96yqU0a0vxB4EnBPoIAfAacCn7wZcUuSJEnSxJq1HsckawFPBfapqgVVdRxwJLDnLXxXewMfqKqzqups4APAc2/h+5AkSZKkiZGqmp07SnYCflFVtxloew3w4Kp6wtC+bwVeCdwAnAt8rKoOGNhebfsqwC+BV1XVae22+cAjq+o37d87Az+tqnVGxPRCmh5KgDsBf79FHuzNtxFwUddB9JDPy2g+L0vyORnN52U0n5fRfF6W5HMyms/LaD4vo/m8LKlPz8nWVTVv1IbZHKq6NnD5UNt8YImEDvgqcCBwPnA/4BtJLquqw9rtDwZ+DdwGeDvw7SQ7VtX17f3MH7qPtZOkhrLkqjqwvZ9eSXJ8Ve3cdRx94/Myms/LknxORvN5Gc3nZTSflyX5nIzm8zKaz8toPi9LmivPyWwWx1kArDvUti5wxfCOVfXXqjqnqm6oql8CHwaeNrD9mKq6tqouA14ObAvcZZr7WRdYMJw0SpIkSZJmZjYTx5OB1ZLccaDtnsCowjjDChhXGXVw+4nt7S7rfUiSJEmSRpi1xLGqFgKHA/slWSvJA4HdgUOH902ye5L126U17gu8DPhWu22HJDsmWTXJ2jTFb84GTmqvfgjwqiSbJ7kd8Grg8yv68d3Cejd8tid8XkbzeVmSz8loPi+j+byM5vOyJJ+T0XxeRvN5Gc3nZUlz4jmZteI40KzjCHwWeARwMfD6qvpSkl2B71XV2u1+hwGPBG4FnAV8oqo+0m57GHAAsAWwkKY4zv9U1T/a7QHeA/xne7efBl7nUFVJkiRJWj6zmjhKkiRJkuae2ZzjKEmSJEmag0wcJUmSJEljmTiql9riR/9McquuY+mbJL5vtVTte+hg30OLa5+X/XxetDR+Do2WZJUkD0uyRtexqP/a99HPfB+tHDwBVS9V1Q3ADcCtu46lT5KsCiz0ALw4P5iW1L6HHgnc2HUsfdI+Ly8Frus6lj7xPbQkP4dGq6obgW9V1bVdx9JXSbZKcv8kW3UdS9fa99G2mHMsZq4ec/0n9kiS1ZPsmuQZ7d9rJVmr67g69CHgq0kenOT2Sbab+uk6sK60B+CTgQ27jqVP/GCa1geBfZOs3nUgPXMI8OKug+gT30PT+hB+Do1yTJJdug6ib5JsluTnwCk0S9CdkuSYdnm4SbYvcECSrduEaZWpn64D68pcPeZaVbUnktwdOBK4BtiiqtZO8lhg76p6RrfRdSPJdD0lVVWrzmowPZLktcAzgQ/TLFdz05u4qo7uKq6uJfkPYDfgLSz5vExkr1uSM4FNaXpNLmTx52RivwlPchxwP5o1gM9k8edlt67i6prvoSX5OTRakk8Az6JZY3v4PfTmruLqWpJvAmcAb6iqhe2X/+8Etq2qJ3YaXIcG3keDSUfwfTTnjrkmjj3Rnsh8qqoOTXJpVa3fHnBOrqrNu45P/ZHk1Gk2VVVN7LfgfjAtKcmDp9tWVT+fzVj6JMne022rqoNnM5Y+8T2kmUryuWk2VVX9x6wG0yNJLgI2q6rrBtpuBZxdVRt1F1m3kmw93baqOn02Y+mTuXjMNXHsiSSXAhtUVSW5pKo2aNtvujyp2jkCmwNnVdWZXcejfvKDSTOVZNV2mJAG+B6anp9Dmokk/wCeVlUnDLTdAzi8qu7QXWT90A5N3QQ4v689arNpLh5zV+s6AN3kNODewPFTDUnuSzNOfiIl2Qz4MnB/4GJgwyS/Bp5ZVed0GlzHkqwGPID2RAb4VVVd321UnVu/qv7YdRB90s5tfBOwJ3A74BzgUOAdE17Y4rwkXwO+WFW/6DqYvpg6UfHkbhE/h6aX5I40w1U3pxn2fVhV/aPbqDr3XuDHST4DnA5sDTwP2KfTqDqWZF3gYzTTbFYDrkvyZeBlVTW/0+A6NBePuXNqQuZKbh/gO0n2BdZI8gbgazQnfZPqAOAEmoRgM2B94A/AJzuNqmNJ7gycBHwJeBlwGPC3JHfpNLDu/TDJiUneZOGKm7wX+DeaQjD3bH8/DHhPl0H1wCOBBcBhSU5N8q52nvlES7JukkOAq2kSgavaJV1u23FoXfJzaIQkTwB+D9wZuAS4E3B8komdxwdQVQcBzwA2Ap7Q/t6jqg7sNLDufQRYC7gbsCZwd+A2bfvEmovHXIeq9kiSnYAX0HxDdSZwUFX9vtuouuNcgdGSHA18D3h/tW/gJK8BHldVD+00uA61S5U8muYb8CcCJ9Ik11+pqgu6jK0rSc4C7llVFw+0bQSc4NzpRjsP9FnAU4Fzq+oeHYfUmSSfB9YB3sCi3pJ3AFdW1bTzQldmfg6NluTPNL1FPx1oewjwsaq6W1dxqZ+SnAdsV1VXDrStDfyzqjbpLrJuzcVjromjesu5AqMluQSYNzhHqx26emFVrd9dZP2RZE1gd+AlwC5VNafWSbqlJDkbuMeIxPFPVTXp5eEBSLIJzfCpvYA7VtW6HYfUGU/uluTn0GhtXYZ5g1Mk2s+hi6pqvc4C61iSVwFHV9Ufk9yPZuTYDTS9jr/qNrruJDkNePDgvL0k2wDHTHiF7zl3zHWOY08k2W+aTdfQzGH7flWdP4sh9YFzBUY7B3gwMLj0xq5t+8RLcmvg8TTDhXYGju02ok59DTiqHQJ/Bs176E3AVzuNqmNJ1qPpYdwD2AX4Ic3w3SM7DKsPrgbm0Rxvp2xE8zk0qfwcGu2PwKtZfNj7q9r2SfZK4DPt5XcD+wNX0KwHer+OYuqDTwM/SrI/i95HrwQmfQjvnDvm2uPYE+0k4ScDv6UZprolcF/gKGALmvHgT62q73cWZAeSPIzm5G6qsMdhVfWTbqPqVjuH5EvAt2kONtsAjwWeU1Xf6jC0TrXrnu5BM0z1rzQFLb5cVed1GliHkqxBkygu9h4C3l5Vvf1gWtGSXAn8kua5+EZVXdZtRP2Q5E00Pa/DJ3eHVtXbu4ytS34OLamda38Uzby1M4GtgIXAE6rqpC5j61KSy6tq3STr0LyH5lXVDUkum/Ce2NB84TL8WfTZmuBEZC4ec00ceyLJV2k+jI4YaNudZnjDM9p1x15ZVTt2FaP6I8n2wNNZdAD+alWd3G1U3UryV5oPoi9V1T+7jkf9lWQP4NdV9a8km9L0mtxIs2j3JH/R4MmdZqwdmroLi14rvxmcCzqJkpxIU6tiB5q6A09qK4qeWlUbdhud+mYuHnNNHHsiyXyadRwH562tClzafnt10+XOgpxlzhWYmXY+342T3IOk0ZI8FDitqk41QVokyUnAo6rqjCRfapuvoukdmOiqkFqcn0Mz0x5rbqyqn3cdS5fakS+fBq6lGSX2+/aLqj2r6jHdRtedJM8C/lhVJ7VffB9E81n0kqr6W7fRaVm4HEd//JOmkMegF7ft0Ix5vpLJ8krg1Pby1FyBt9PMFZhYSd7frvFJksfRlEK/tC2PPrGSvCrJju3lXZKc0S61cP+OQ+vSJ2hOcqF5/6xO82E96fNKNm+TxtWARwEvpDn+PqDbsLqV5FlTy/ok2T7Jz5P8tB2WOKn8HBqhfW08sL38OpqpAV9K8sZuI+tWVX23qm5XVdsMVMX/Gs0Uikn2dppzFYAPAL8Dfk7zGTWx5uIx1x7HnkhyL+BwYFWatVw2pznhe0pV/V+S3YA7tWsETQTnCoyW5Fzg9lV1ZZLf0BRvmA98sKomdi26JGcCd6uq+Ul+CnyLpijBC6tqIosSDLyHVgPOp5k/cS1wzoQvJXAWcG+aNcXeWlW7tvNBL6yq3q6ftaIl+SfwgKo6P8lRwN9p1rvcraoe1m103fBzaLQkFwMbt8/FKTSJ0RXALya8SuZdgYvb99DawP/QfFn3vsHKmZNm4H10a+BcYFPgOpoqvBt0G1135uIx16qqPdEmh3cE7g9sRvPG+tXUfIGqOgY4psMQu3BmkgfQzBU4pv2AWpdFPSiT6jZt0rghTRnnbwAk2brjuLp22zZpXIdmsft/a18zH+g6sA5dnma5ibsBf62qBW2CtHrHcXXtozTfeK8BvKJteyAw6UOm5rUnMLcGHgQ8jfbkrtuwOuXn0GirAJXk9jSdEH8FSDLpS0IdRlN/4Hzg/cCdaCpnfgrYs8O4unZhkjvQFHr8XVVdk+Q2QDqOq2tz7phr4tgjbZI4acnhOP8DfJ12rkDb9niayrOT7OQkzwbuAPwIblqb76pOo+qeJ3hLMkEaoarek+QI4IaBQkpnA//ZYVh94MndkvwcGu044GM0X3QfAdAmkb094Z0l21TV39uiJ08B7krz2Xzq+Kut9N4G/J7m8/gZbdu/ASdMe43JMOeOuQ5V7VA7tG6p/4BJHvYxLMnqcFOSPZGS3Af4MM2JzPOr6p9tIvnoqprYbzSTPIZm/SyLEgxoCxHclCC1f9+qqv7cbWTqmyTPpTm23AA8o6p+lGb5n1dV1UO6jK1P/ByCdsTLq2l6R95bVQvbOfd3rKoPdRpch5KcT/Ol7l2Bj1fVzu1UgUsmqbjhKG1CxNSQ3SQbA6tMeKG25zLHjrkmjh1K8uCBP+8D7A18hEVrufw3cEhVTeRQO+cKaKaSrAI8hGZ+zTUD7RN/gjfIyodaGk/uFufnkJZFkg/SDDlcB/hYVX2sLWZ3UFXds9voupNkHnBVO11iVZq1C2+kWa/wxm6j69ZcO+aaOPZEkr/QlIc/e6BtC+D7VXW37iLrTpITgKe3wz4+yaK5AhdNeM/a4BILm9FU+nOJheSKqlqn6zj6JMnPgTdW1S/ayoevAq6n+Sb8nd1Gp77x5G5Jfg6NlsWXKdkF+CouUwJAkkcC11XVT9u/dwbWraqju42sO20hvxdX1R+SvBt4Ak1v9U+r6pXdRteduXjMNXHsiSSXANtW1fyBtvVoFo2dyMnmSeZX1W3buQLnMzBXoKo27ja67sQ16EZK8h3gbVX1665j6QsrH2pZeHK3JD+HRrOKtZZFkktp1iqvtqr1A2iqh55YVZt1G1135uIx1+I4/XEkcGSStwNnAVsCb2jbJ9XVbYXMuwJnVNVF7VyBW3ccV9eG16C7aYmFbsPq3OnA95J8C1hs/nBVvbmzqLpl5UMti+2BP7aXn8PAyR3NeoaTyM+h0axiPUL72ngp8GCa9bdvKnJSVbt1FVcP3ACs0c6xn9+ew6wCrN1xXF2bc8dcE8f+eDHwVuCTwO1oluP4KrBvhzF17UvA0bRzBdq2e2F1MpdYGG1N4Jvt5S06jKNPrHyoZeHJ3ZL8HBrNKtajfRB4GHAg8A7gf4GXAF/uMqge+B7NOe2GLHou7kpTzXqSzbljrkNV1WvOFVhSO1ftv2iXWKiqL7fzHt/tECENGqp8+L72S4aJr3yo0ZIcCqxLc3L3g6p6W5K7AV+vqjt3G113/BxaUpLHAp/GKtaLSXI2cP82AbisqtZLcmfgU1X14KVdf2WV5FY0BSCvo5m/d32ShwCbVtXEJtVz8Zhr4tihJLtV1THt5YdNt98kfzgBJNmSZnimc9daLrEwvXbo1PAQoX91F5E0N3hyNz0/h5bOKtZLzOU7F7h9VV2Z5PJJX44DbqqAvklVndt1LH0wF4+5Jo4dSvKXqYqp7UTz60fsVlW13exG1g9JtgIOA3akeR7WTvI0mvUKJ3qh7vYDehfgdlX1lSRrAVTVwm4j605bNv+LNPNtiiZxLICqWrXD0DrTfii9GXgWsGFb5OORwPZV9bHx19ak8uRuET+Hptf2pP07zWvlv9u/16iqP3UcWmeS/JJmJNBvkxwFnARcDjy7qu7SbXTdaYs9fgJ4Gk3v/Vpp1iu8b1W9qdPgemAuHXNX6TqASTaQNK4KzAPuXFXbDv1MZNLY+hTwHZq5JVPfYP4IeERnEfVAkrsDJwMH0Sx4D81E/M92FlQ/fAL4KbABzQf1+jSvob27DKpjH6SZC/tsFhULOpFmzo20mCTrtZWarwZOadue2BZtm1R+Do2Q5N+BY4HNaZYQgGZe1v6dBdUPL2fR6+RVNPNhHw+8oLOI+uGTwHwWFfMD+BXwjM4i6oG5eMy1x7En2rWiHlNVk14Z8ybtUgLzqurGJJdU1QZt+2VVtV630XUnyXE08yUOTXJpVa3f9jieXFWbdx1fV9ohQhtX1XUDc0vWAv5SVdt2HV8X2qFSd6iqhb6HtDRJvgxcCuxHU3hr/TTrjP2yqu7YbXTd8HNotHZZqGdW1QkDn0OrA+dU1byu45tN46YaDZrkaUdJLqQZIXXd0PtoflXdtuPwOjMXj7lWVe2PLwLfTvJhmuU4BpcSmNSDzfnAHWh614CbhiOe0VlE/bAD8IX28tRQzIVJ1uwupF64mqay7HXARe0Qs0tpJp1PqmsZOs63H0oXdxOOeu7hLDq5mzq2XJhkYtcrxM+h6WwMTA1JrYHfk9gb8Zml70IBkzyCbD5N7YGbhmK2n9G9H5q5gs25Y66JY39MDR1761D7JB9s3k+TTL8LWC3Js4A3Au/uNqzOnQbcGzh+qiHJfWmHOUywY4GnA58Hvk5T/vsamlL6k+prwMFJXgmQZDPgQ1gaXqN5crckP4dG+z2wJ3DIQNszgd92E053JnVEyzL6NPCNJP8LrJLk/sA7aYawTrI5d8x1qKp6LcnuwItoxsWfQTNE85udBtWxJI+n+YbzkzRLLbyDZh3QF1TVD7uMrS/aieZ70MxLOmRSiwalWd/zPTTza24DXEkzN/Z1VXXtuOtq8iR5PfBEmrXnjgAeQ3Ny961JXr7Fz6EltYVwfkiznuUuwM9oFjN/ZFX9o8PQ1ENJAryMofcR8OGa4ERkLh5zTRzVS23BoJ8Aj6qqa7qOp2+S7ESTDGwNnAkcVFW/7zaqfphL1clWpPY99BbgHVV1TTtE9aJJ/pDWeJ7cLc7PodHa18m2wEXAo1n0OfTtqlrQZWzqn/Z99Fnghb6PFjcXj7kmjuqtJKfTVJq9qutY+qI9AJ8M3NUD8OKSrA98HMt93yTJRTQFg27sOhb1myd3o/k5NFqShcA6Hls0E22htq0meY3PYXP1mOtyHOqzfYEDkmydZNUkq0z9dB1YV6rqBuAG4NZdx9JDB2C572GH0AxjlsZqjy2PBEwEFufn0Gh/oBmaKs3EB4F92+kTYu4ec+1xVG8lmXozDb5IQ7MI80Qu6A6Q5KXA7jTj4Icr8P6rq7i6ZrnvJbVLt9wPOJtmKNnga2W3ruJSPyV5LbAe8FbnwDb8HBqtXWfuOTTFyIaPLZO+prCGJDkT2JTmi+8LWfz1slVXcXVtLh5zTRzVW0m2nm5bVZ0+m7H0ycCJzLBJP5E5Bdi1qs6dShzb6mQ/rKo7dx1fF5LsPd22qjp4NmNR/3lytyQ/h0ZL8tNpNlVVzWhdQ02OJA+ebltV/Xw2Y+mTuXjMNXGUtFKYi9XJpD7x5E6SZs9cPOaaOKq3khzK6MWEr6EZovnNqjphdqNSX83F6mQrWpL/mGbT1Hvo13NpUr402/wcGm26OZ4Wy9EoSfabZtPU++j7VXX+LIak5WTiqN5K8jGaBYaPpJlDsSXwBJrFy9ej6V16cVUdMt1trIySHMv4E5nDq+qo2Y1KfZTkZ8D9gfNpXhtbAJsAxwPbtLvtXlXHdxGf+sWTuyX5OTRaO2Vi1OfQ9cA5wOHAW1yeQwBJvgw8Gfgti95H9wWOovlcujvw1Kr6fmdBdmAuHnNX6zoAaYztgcdW1S+mGpLcH9ivqh6R5NHAh2gqR06SnwF7Awez6AC8F/AlmqINn03yvqp6b2cRdiTJnYB7AmsPtk9wsYYTab5I+MhUQ5L/Bu4MPIhmWO9HaZJLaXumP7l7AvCJJJN2cufn0Gj/D3gS8G6a18pWwGuB7wB/p1lD9kPAf3YTnnpmFeCZVXXEVEOS3YE9qmqXdj7+u4FJOrbAHDzm2uOo3koyH9iwqq4faFudZhHz27ZDE6+oqrWnvZGVUJLfAM+tqpMG2u4MHFxV90tyX+Cwqrp9Z0F2IMkbgTcDJwBXDmya2GINSS6leQ/dONC2Ks17aP0ktwIumNSqs1pckq/SHDtGndw9oz25e2VV7dhVjLPNz6HRkvwTuFdVzR9oWw/4fVXdPsnm7eVNu4pR/dG+jzZol6CYalsVuLSq1h283FmQHZiLx9xJX4dI/fZH4B1Jbg3Q/n4bTWIAsC1wSTehderOwPCyG6cDdwKoqt/SDEecNK8A7ltV96uqhw78TGTS2Dqf5lvLQY8DLmgv3xpwQWZNeRTNkMxB36YpNAXwBWC7WY2oe3/Ez6FR1gVuM9R2G2DqS6jzgDVnNSL12T+Blwy1vbhtB9iIxb/wnRRz7pjrUFX12d40wy8vT3IJsAHN3Kxnt9s3AF7aUWxdOgb4XJI3s2je2luB4wCS3B04t7PounMV8Leug+iZlwFfS/IXFg2DuRvw7+32+9EMVZVg0cndxwbaJv3kzs+h0Q4BfpTkwzTHli2Al9NMoYBmYfO/dxSb+uc/gcOTvI5mXeHNaZageEq7/U7APh3F1qU5d8x1qKp6L8mWwO2Ac6vqjK7j6VqSDYBP0BxwV6PpMToc+H9VdVE7z2+dSSt4kmQv4IE0SfRik8knudJfko1ovr28Hc0XCt+pqou7jUp9lOReNMeSVRk6uauq/0uyG3CnqjqowzA74efQ4tqqqi+k+RJq6tjyVeCgqrqh7ZlNVV3VYZjqkXaI9y4ser38qqomesTLXDzmmjiq15JsCDwW2Kyq3pvkdsAqVXVWx6F1rv3gngdcOMmJ0ZS2yh8sXukvNHMcV+0gpN5oT3o3r6pfdx2L+s2TuyX5OSTdfIPHlqr6SpK1AKpqYbeRdWuuHXOd46jeahdG/TvNkKCpIQx3BA7oLKieaIvh/C+wT1XdmOROSe7RdVwd27b92W7gZ+rviZRkqyS/oBnC++O27WlJPt1tZJoLquoYYI2pE7xJ5OfQaGm8IMlPkvypbdstydO7jk39006hORk4CPhM2/xgYFIrno80F465Jo7qsw8Bz6iqR9OsDQXwG5pSxRMryb8Dx9IMadirbV4H2L+zoHqgqk6f7qfr2Dr0KZry+OuwqAjOj4BHdBaResuTu5E+hJ9Do+wHPJ/mtbJV23YW8LrOIlKfHQC8uaruzKLPop/TLAs1sebiMdehquqtJJdW1frt5UuqaoN2eOaFVbVhx+F1JslJNOshnTD1HLVDHc6pqnldxzebkhxYVS9sLx/K6AWpqaq9RrWv7JJcDMxre6UvqaoN2vbLqmq9bqNT3yQ5DvhUVR06cGxZCzi5qjbvOr4u+Dk0WpIzgZ3aefVTr5UAl0w9X9KUdmmoDaqqhj6Lbro8iebiMdceR/XZX5M8aqjt34A/dxFMj2wM/Km9XAO/J/FboFMHLp9CU4ls1M+kOh+4w2BDkrsCE1/cQyPtQFP+HdrjSTv/aJKXVfBzaLRVgQXt5anPnrUH2qRBpwH3Hmxo15w+pZNo+mPOHXNdjkN99mrg20m+A6yZ5FM0a9Lt3m1Ynfs9sCdNOfQpzwR+2004nfpNkql1Go/tNJJ+ej/Ne+hdwGpJngW8EXh3t2Gpp06jObm7qSKzJ3d+Dk3je8D+SV4JzZxHmvUtj+o0KvXVPsB3knySZg7fG2iWnXhBt2F17jTm2DHXoarqrXY40KbAc4CtadaK+sKkV7JrC+P8kKa3bRfgZ8D2wCOr6h8dhjbrkpy69L2oqprkAjm7Ay+ieQ+dQTMs5pudBqVeSvJ4mnk2n6RJmN5Be3JXVT/sMrau+Dk0WpJ1gc/TVJtdHbia5nNpr6q6osPQ1FNJdqJJFKfeRwdV1e+7japbc/GYa+KoXkoyNQxmvaq6put4+qL9Vndb4CLg0Sw6AH+7qhwipJu076GfAI/yPaSZ8uRuET+HRmufl72BLwHr0r5Wquq8TgNTL7Wvl5OBu/o+WtJcO+aaOKq3kpwAPKaqzuk6lj5JshBYx7UbtTRJTgfu7CLcWhpP7kbzc2g0C2xpWSQ5GbhPVc3vOpa+mKvHXOc4qs++SDO35MM0Zb5v+pajqo7uLKru/YFmaOrfug5EvbcvcECSt7Dke8gvHnSTqrohyQ3ArYE5cxIzC/wcGu2oJE+oKuc0aiY+BHw1yTtZ8n30r66C6tJcPeba46jeGjN/bdLnrL2dZr7N52mGNQwegHu79o9mX5Kp5HDwQB+a99CqHYSkHkvyUpqiL57ctfwcGi3J14AnAr9iyc+hiVz+SNMb+CwaNtGfRXPxmGviKM0xSX46zaaqqodNs00TKMnW022rqtNnMxb1nyd3mql2FMNIVbXvbMYizVVz8Zhr4qjeSvKtqlqi5HmSw6vqKV3EJEmaLElWAx4AbE7TK/Crqrq+26ikuSPJR6rqZSPaP1RVr+ggJC0nE0f1VpLLq2rdEe2XVNUGXcTUB0nmAVdV1YJ2cvVewA00JeKdt6abJDmUxYepTrmG5gT4m1V1wuxGJc0d7fJHR9EsyH0msCXN0hNPqKqTuoyta+0aus8CbgecA3y5qn7SbVTqozHncxdX1YZdxNRHSbYDbqyq07qOZToWx1HvJNmvvbjGwOUp2wGTPsTu2zTr/PyBZlz844HrgJ2AV3YYl/pnPrAncCSLTnqfAHwZuAvwuiQvrqpDugtRfZHkWMZ/0XD4BBZD+QRwIPD+ar9pT/Katv2hXQbWpSSvBl4HfI7ms2gr4EtJ3ltVH+g0OPVGkv9oL642cHnKdjRLi02sJIcBH62qXyZ5Hs1x5cYkL6uqz3Qc3kj2OKp3knyuvfhsmop2Uwo4H/hMVZ0y64H1RJJLgQ2qqpKcRTOEagFwYlVt1m106pMkPwT2rapfDLTdH9ivqh6R5NHAh6rqzp0Fqd5I8jaa9fkOZtEXDXvRrNcX4PnA+6rqvZ0FOcuSXALMq6obBtpWAy6sqvW7i6xbSc6mWSP2LwNtOwA/qqrbdReZ+mSgJsOuwLEDm6bO5z5cVb+e9cB6IskFwBZVdW2SP9N0ClxGMxrojp0GNw17HNU7VfU8gCS/rKqDuo6nh26g6Y3dHphfVWckWQVYu+O41D/3A34z1HY8cN/28g+ALWY1IvXZI2mSgZuGYCb5InBwVd0vyeHAYcDEJI40QzAfDAwuvbFr2z7phr/A/Reje6w1oarqodBUg6+qN3UdTw+t0SaNm9N0CPwCIMkmHcc1LRNH9dkvkmxSVecnWRv4H+BGmm+8r+w4ti59D/gqsCHNkEOAuwJndxaR+uqPwDuSvKWqrk5ya+CtwNS8xm2BSzqKTf1zZ5qT/0GnA3cCqKrf9vmEZgV5I3Bkkm/TPBdbA4+jWRJporRfUE55K/CZJG+lGca8JbAPMG21VU20DydZ29oMS/hjkjfQHFe+A9AmkZd3GtUYDlVVbyU5AXh6Vf09ySdpTl6uBi6qqj27ja47SW5FM5zsOuDQqro+yUOATavqy+Ouq8mSZBuaYYY70ySIG9D0OD67qk5NsjPN6+bb3UWpvkhyFHAF8GaaZGALmgRhvap6fJK708xz7OUQqhWlHd3xdBYVgflqVZ3cbVSzr106YOqkMQObBtt6u4yAupPkN8CLq+oPSd7DotoMP62qia3NkOT2wNtonov/qaoLkjwNuE9Vva7b6EYzcVRvJZlfVbdNEpqx8HcFrgJOraqNu42ue+23v5tU1bldx6J+S7IlzUnvuVV1RtfxqJ+SbEBTnOEpwKrA9cDhwP+rqouS3AlYp6qO7zBMdWTcurCDXCNWw6zNsKS25/UtwDur6uqu45kpE0f1VpLzgTvQJIwfr6qd26IEl4wq6zwpkqxHc3L3NOC6qloryROB+zqHQKMk2ZihObBVNTwkUQJu+lJqHk0BmIkbRjZmGZvFVNVesxCONOcluYhmHdTtaZZt2aE9zsyvqnW6ja477fOy8Vw6zjrHUX32JZqCBOsAH2vb7gWc2llE/fBJ4FKaMfF/bdt+BXwAMHHUTdqqqZ8Bhr/RLZoeJWkxSW5LMy1g7fZvAKrq6DFXW9lMbNXumXKNWC0jazOMdghNJdVPdB3ITNnjqF5L8kiaXrWftn/vDKw7YScxi0lyIXC7qrouySVVtUHbPr+qbttxeOqRJP8E3kdTFfOqruNRvyV5LvBxmiFkgwXIqqq26ySoHkjyCJqF7jdu53r6OZR8jOnXiF0PeCLNnDbXiJW1GaaR5Dia6udn07yPbkrKqmq3ruIax8RRvZdkK5ohDmc7PwuSnALsWlXnTiWO7XP0Q9fj06B2DboNywO9ZqBdm+8/q+p7XcfSF0n+H/By4NPAG9p59zsAB1XVA7qNrjuuEavlMVWbATh/Lg3PXFGS7D3dtqo6eDZjmSkTR/VWks1ovr3chaYi5IY0QzKfVVUTu4ZWktfTfJv7v8ARwGOAdwLfqqoPdRiaeibJ+4CTquqzXcei/mvnld9ucLH7Sdf22j+8qk5LcmlVrd8WtbigqjbsOr6uJJlP86XU9QNtq9NUPZ8qandFVbm+sEiyLvBR4JnA6jQ9j18GXlZV87uMTctmlaXvInXmAJr15jZoq26tT7Mu3Se7DKoH3gN8hWZI2erAZ4FvAR/uMij10i7AAUlOTnLM4E/XgamX3gO8aWi9vkm3Ds0QMlg0jGx14NpuwumNP9KsEXtrgPb323CNWI32EZp503cH1mx/36Ztn2hJnpfk6CR/b38/r+uYxrHHUb3VVpvarKquG2i7Fc2Q1Y26i0yaG+biMBh1J8mZwKY0SdHFg9uqaqtOgupYkq8Df6iqdwxMDXgtsGNV7dF1fF1p14g9DLg3rhGrpUhyHrBdVV050LY28M+q2qS7yLqV5H+BvWiKG55OU/TwlcAXquodXcY2Hauqqs8upam6NViZ7U7AZZ1E0yNtsYZn0hRreILFGjSKyaGW0XO6DqCH/h9wVJIXAOsk+TtwBc0C5pNsq6q6fzu/fjPaNWKTPItmrWXX+tSgq2mW+Blc43Mjmiq8k+w/gYcMrn2a5AfAMYCJo7SM3gv8OMlnWPRNzPOAfTqNqmNDxRqe1jZfRTPkY2KLNaiRZM+qOrS9/B/T7ee8Rw2rqp93HUPftEXI7gPch+Yz6Ezgtxb24OtJPge8qU0Y10vyFWAnmp5IadCngR8l2Z/Fe9YO7DSq7q0FXDjUdjHNcN5ecqiqei3Jw4A9gNsB5wCHVdVPuo2qWxZr0DhJvltVj20v/3Sa3aqqHjaLYamnkvzv1JCoJPtNt19VvXn2olLfJbkd8DmaCpkfBd4KfBd4VVUt7DA09VBbLOl5DJ3PAZ+d5KrfSQ6hmUf9euAMmoT6HcCVVbVnl7FNx8RRmmOSXEAz9/OGgTk3t6YZHjS80LskTSvJAVX1kvby56bbr6p6XbBBsy/JmsBvgB2Az1TVCzsOSZpT2mqzHwOewaJqs1+hqTZ7WYehTcvEUb3VlvZ+E80iw1PfUB0KvKOqJraincUaNFNJ/lBVO41oP76qdu4iJklzX5IdgS8Ap9AMQ/wQ8FvgpX094VW32mqhe9Kuyw0cWlXTflk1SdpK1hvRLGfT62HwJo7qrSQfBO4L7MuiMfH7AMdX1Su7jK1L7fqWR9EcZDYH/kVbrKGqzusyNvVLkiuqap2htgAXV9UGHYWlnpr6ImpE+wVVtXEXMamfklwMvLaqPtP+vRbNPPtHVtWWnQan3pmL1UNnS5I7Ak9nUQfJV6vqH91GNT0TR/VWkrOAe1bVxQNtGwEnVNXm3UXWnfZbqYcAv6JZB8liDVpCO28CmuEvXxnavA3NsX/XWQ1KvTfNFw2rA+c5f1qDkmxXVf8a0f7Eqjqyi5jUX0lOZcnqoVsDx1TV1t1F1q0ke9AUCPoOTUK9FfA44EVV9aUuY5uOVVXVZ1nG9pVeVd2Y5Fvtyd1v2x9p2D+nuVzAL4CvzW446rMkx9K8Nm6d5JihzVsAv5z9qNRno5LGtt2kUaPMueqhs+TtwGOr6qbjbpJdaaZlmThKy+hrNOtn7cuialNvAr7aaVTdOybJLlX1664DUT9V1b4ASX5dVT/oOh713qdpvpC7D/CZgfYCzgdcH1bSzfF94ItJhquHTvrn0zo0I8gG/Zom0e4lh6qqt5KsQZMoDpdvfntVTeyisUk+ATwL+BbNMNWb3sSWzNegJA8FTquqU5NsCrwHuBF4g/NhNSzJnavqb13HIWnlMherh86GJG8ANgD2qaqr20rF+wKXVtW7uo1uNBNHaY6xZL5mKslJwKPaBbqnhr1cBcyrqid2GJp6KMmzgD9W1UlJ7kQz9+ZG4CUmlJJurrlUPXRFSTL4hX+ATdu/LwXWb9vOraqtuolwPBNH9VqSh9H0rk31OH65qn7SbVTS3JDk8qpaN8lqNEMOtwauBc6pqo26jU59k+SfwAOq6vwkRwF/BxYAu1XVw7qNTtJcNteqh64oSR48k/2q6ucrOpblYeKo3kryauB1wOdYVG3qecB7q+oDXcbWJUvma6baysT3Bu4GvLWqdm2HgF9YVbftNjr1zcAXDbcGzqX5Jvw6mt4Bl2+RtFzmYvVQjWZxHPXZq4CHVdVfphqSHAr8iGYtoEm1+nBDWzJ/1Q5iUb99FPgdsAbwirbtgYDDDjXKhUnuQLPUz++q6pokt2GCK1lLukXMueqhs6H9Ive5wI7A2oPbqmqvDkJaKhNH9d0pQ3//i4FiMJPEkvlaVlX1niRHADdU1dSyHGcD/9lhWOqvtwG/B26gKWIB8G/ACZ1FJGllMOeqh86Sg4F7AkfRTCfpPYeqqlfaidNTnk+z2P1bgbOALYF9gJ9X1adnPbiOJdmb5pv/A4AXD2y6qWR+VV3XRWzqr3Z+4wOAzWmSxl9W1fXdRqW+ansYqaor2783BlaxCq+k5TUXq4fOhiSXAtvOpcqyJo7qlSQ3sni1qSmDbVVVEzss05L5mqkkd6b5JnNNmqVbtgSuBp5QVSd1GZv6Kcn6wBNY9EXDt6vqkm6jkjTXzPXqobMhyQnAI6tqTvQ2gomjeibJ1jPZr6pOX9Gx9FmSTYD70pS1vinBrqrPdhaUeifJ0cD3gPdXe7BP8hrgcVX10E6DU+8kuT9N8Yq/saiAxV1oXi/Dw8wkaVpzvXroitKuFjBlJ+DfgQ8zNFS1qo6ezbhmysRRvZXkNVX1/hHtr6qq/buIqQ+SPAn4AvAPYAfgRJqqmceZDGhQkkto1my8YaBtNZqqqut3F5n6KMlvgA9W1ZcH2p4BvKaq7tNdZJK0ckhy6gx2q6raboUHsxxMHNVbU6XhR7SPXI5iUiT5C7BvVX0tyaVVtX6S5wE7VNVruo5P/dG+Vl42+M1lkocCH6uqHbqLTH3UzrfZcHBh7iSr0izH4RcNkpZbkh2BXVlypNSbu4pJy86qquqdgW78VduT3MG5jtsBV8x+VL2yVVV9bajtYOA8wMRRg94IHJnk2zRDD7emWTvrOZ1Gpb76B/BMFi+P/+/AP0fvLklLl+SFwAeBHwKPoZlC8UjgW13GpWVnj6N6Z6AbfyvgjIFNRZMcvbuqjpz1wHoiySnAA6vq/CR/AF4KXAT8uqo27DY69U2S7YGnA7cDzgG+WlUndxuV+ijJA4BvAyfTfNGwDXBH4PFV5XI/kpZLe97yvKo6dmCk1GOAZ1bV3l3H15WhAkKDrqFZTeBw4IA+VUI3cVRvJTmkrwugdinJ64BTquobSfYCDgRuBD5QVft0G536qF3mZhPg/MFhiNKwtqrq41j0RcN3raoq6eYYnHqU5GKaufc3OvUo/0MzAugjNJXPtwL+C/gacAnwauCIqnptZ0EOMXGU5pgkqwzNQdoKWMvlFTQsybrAx2gWc18NuB74Ms28x/ldxqb+ao8pmwNnV9UZS9tfksZJ8lfgsVV1WpJfAe+lGSn1taratNvoupPkROARVXXOQNvmwA+raockdwJ+XFVbdhbkkFWWvovUjSTrJtk/ye+TnJ7kjKmfrmPrSluoYmGSW021VdUZJo2axkeAtYC7A7cZ+P2RLoNSPyXZLMnPaeY6Hg6ckuSYJLfrODRJc9t7aZb2AdiPpjL80cC+nUXUD5sBC4baFtKM+IBm2sB6sxnQ0tjjqN5K8gVgC5oJ1V+g6c7/H+AbVfXBLmPrUrtg7GMGv6GSRklyHrBdVV050LY28M+q2qS7yNRHSb5JM6/8DVW1MMlawDuBbavqiZ0GJ2mlkWQNYI2qGk6aJkqSg2mGp76DZk7jFsAbaEZ77NXOO/9UVd29wzAXY+Ko3kpyAXCXqro4yWVVtV7bhX9UVd2r6/i6kuS1NJUPP0xzoLnpTdzXBWPVjSSnAQ+uqtMH2rYBjqmqrbqKS/2U5CJgs6q6bqDtVjQnMRt1F5mkuaadW79UkzzvPsmtgbfSVK++HXAu8FVgv6q6MsmmNAl2b0bamTiqt9qTmE2r6vokZ9Esdn8FcNmo9R0nxZjFY3u7YKy6keRNwF7A/ixajuOVwKFV9fYuY1P/JPkH8LSqOmGg7R7A4VV1h+4ikzTXJLmR0RVDF1NVq85COLqFuI6j+uwE4MHAT4BjgU/QjAWf6KUEqmrbrmPQnPEOmsqYe7CoSuZ7gc92GZR6673Aj5N8hkVfNDwPsFqzpGU1eK7yOOBpwLtYdGx5HfCNDuLqVJLdquqY9vLDptuvryPI7HFUbyXZDqCq/pVkY5q5NmsD+05yMZgk36qq3Ue0H15VT+kiJkkrh/ZEZvCLhsOq6ifdRiVpLmvXcdy5qi4baFsfOL6qbt9ZYB1I8peqult7ec6NIDNxVG8l+Qjw5cGFp9uJwk+vqld0FljHBtdDGmqf6PWQNFqS/wCexaJE4MvAZ8uDvyRpFiS5ELjniGUnTnD+9Nxi4qjeag80m1fVtQNttwLOrKqNu4usG0n2ay++lmZI2aDtgB2qaqfZjUp9luS9wO7Ah1g0POhlNAWmerOgsPqhrXT4Jpb8ouEdVXV1l7FJmruSvB94LM1n0ZnAljSfRT+sqld1GFrnkqwO7ALcrqq+0lazpqoWdhvZaM5xVJ8VS641uuqItkkxtQDsKgOXoXmezqSpzCUNei5wr6o6a6ohybeB/6P5AkIadABwJ5oTuqkvGt4IbA78R4dxSZrbXgucAjyDRV9KfQw4sMugupbk7sCRwDU0S3F8haa2x940z1Xv2OOo3kryDeBU4LVVdWNb2vndwB2r6sndRtedJC+oqoO6jkP9l+SfNInj/IG29YDfT9q8Ei1dkouB2w/NQ9oAOMVh8JJujiSbAPcDFhuaWlUTW6wtyXE06zQemuTSqlq/7XE8uao27zq+UexxVJ+9HPg2cG6S02kWST0XeEKnUXXvquGGJAFeX1Xv6iAe9chUUanWh4DDk7ybZs3PLYH/AT7YQWjqv/OA2wCXDbStSXPclaTlkuRJwKE0vY47ACcCdwOOY7KrfO8AfKG9XNAMUU2yZnchjWePo3qt7WW8L80J75nAbyd5sVi4aa21/wNeXFWXtonCocCNVbVrt9GpawNrZ2XMbuXaWYIlysHfl6ai6kdZ9EXDfwFfqqr3dBCepJVAkr/QVMT/2kDP2vNoajO8puv4upLkD8ALqur4qQKHSe4LfKyq7tt1fKOYOEpzTDuM4UPAo4HPAy8F3g+8Z9KTaknLZkw5+EG9LQ0vqf8Gq8EPJI6rAOdNYrHDKUkeD3wG+CTwapq1l19Mk0z+sMvYpmPiKM1BSeYBP6EZ6nEw8B8ur6BhST5SVS8b0f6hSV7SRpI0e9p1HB9YVee3vWwvBS4Cfl1VG3YbXbeS7AS8gKYY2ZnAQVX1+26jmt6kVqeU5qwkjwNOAH4K3IOmCuKxSbbtNDD10XOnad9zNoPQ3JDkW9O0Hz7bsUhaqRwEPKi9/EGa85cTgE90FlFPVNUfquqlVfW4qnpxn5NGsMdRmnOSnAk8r6p+3P69CvC/wCsm/Zs7NZJMLZ3wMeC/hzZvB/x7Vd1pdqNS3w0OJxtqv8SqqpJuKUm2AtaqqpO6jqVL7dq5zwV2BNYe3FZVe3UQ0lJZVVWae+4B7JzkM8DGVfWEJN+jWQdIgkU9imuweO9iAefTrBElAZBkv/biGgOXp2xHs6ajJN0iquqMrmPoiYOBewJH0Xw2956JozT3PBt4BfBp4Glt21XAk4D3dhOS+qSqHgqQ5O1V9aau41Hvbdn+XmXgMjRfNJwJvHW2A5KkCfBoYNvBtXP7zqGq0hzTLur+8Ko6baA62arABQ5V1ShJNmbJYTD/6igc9VSSF1TVQV3HIUmTIMkJwCOrak70NoI9jtJctA5NLwC0C8YCqwPXdhOO+irJo2gWV95saFMBruOoxVTVQUluS1Nwa/iLhqO7iUqSVlqHAN9K8mGGhqr29Zhrj6M0xyT5OvCHqnrHwIKxrwV2rKo9uo5P/dH2Tr8POLiqruo6HvVbkucCHwcWAFcObHIdR0m6hY1ZR7e3x1wTR2mOSbIZzUTqjYDNgX8BVwCPr6rzuoxN/ZLkEmBD1/jUTCQ5G/jPqvpe17FI0souyTOr6ssj2verqjd3EdPSmDhKc1CSAPdh0YKxv62qG7uNSn2T5H3ASVX12a5jUf8lOR+4XVXd0HUskrSyS/Iv4L8Gv6xL8k7gMVW1U3eRTc/EUZJWUkmOBe5Ls5zCYr3RVbVbJ0Gpt5K8imYO9dv8IkqSVqwkdwG+Dzynqo5Nsj+wG/CIqrq02+hGM3GUpJVUkmnXa6yqg2czFvVfkjOBTWkKbV08uK2qtuokKElaiSW5F/At4BfAVsCjq+rybqOanomjJEkiyYOn21ZVP5/NWCRpZZTkYSOadwNeBLyYpmaFVVUlSbOrnQv7n8CzgI2q6h5JdgM2raqvdhudJEmTZUwl1UFWVZUkza4kbwMeAXwI+GRVrZdkO+BrVXXvToNT7yS5FfBmmi8aNqyq2yZ5JLB9VX2s2+gkSV0zcZSklVQ7Z22nqrooyaVVtX7bC3lJVa3fdXzqlySfoFni593A99ovGjYHflhVO3QbnSSpa6t1HYAkaYVZlWYxd4CpbwnXHmiTBj0ZuENVLUxyI0BVnd0mj5KkCbdK1wFIklaY7wL7t0MQp+Y8vg04qtOo1FfXMvSFcpJ5DFVYlSRNJhNHSVp5vQrYDJgP3Jamp3Fr4HVdBqXe+hpwcJJtAZJsBnwM+HKnUUmSesE5jpK0kkuyCc36UGdW1Xldx6N+SrIG8B7gBcBtgCuBg4DXVdW1XcYmSeqeiaMkrUSSpNoDe5JpR5VU1Y2zF5XmmnaI6kXlSYIkqWXiKEkrkSSXV9W67eUbWVQU56ZdaNaIWnXWg1PvJNmmqk5rL0+7blhV/WvWgpIk9ZJVVSVp5TK4bMK2nUWhueLPwDrt5VNovmjI0D5FU6FXkjTB7HGUJEmSJI1lj6MkrUSSHMqSw1OXUFV7zUI4kiRpJWHiKEkrl1MGLm8E7E2zbuPpNJVVnwAc3EFc6qEkxzKzLxp2m4VwJEk9ZuIoSSuRqtp36nKSHwCPq6pjB9oeBOzTRWzqpU8PXL498B80XyxMfdGwN/DZDuKSJPWMcxwlaSWVZD6wUVVdN9C2OnDxVOVVaUqSXwPPr6oTB9ruCny2qnbpLjJJUh9Mu8aXJGnO+wPwziRrArS/3wH8scug1Ft3Af451HYqcOcOYpEk9YyJoyStvJ4LPBCYn+R8YD7wIMDCOBrl58Dnk9wxyZpJtgc+Axy7lOtJkiaAQ1UlaSWXZCtgM+Dcqjqj63jUT0k2AD4BPIVm3cbrgcOB/1dVF3UZmySpeyaOkjQBkoSBhd2r6sYOw1GPJVkFmAdc6OtEkjTFoaqStJJKcrskRyS5mKb36LqBH2k6awG3AbZJsl2S7boOSJLUPRNHSVp5fQq4Fng4sAC4F3Ak8OIug1I/Jblrkj/QzIU9pf35R/sjSZpwDlWVpJVU29O4VVUtTHJZVa3XzmP7ZVVZKVOLSfIz4P+A/WiqqW4DvIvm9fKF7iKTJPWBiaMkraSSXABsWVXXJDkNuA9wOXBRVa3TaXDqnSSXAhtX1XUDXzSsBfylqrbtOj5JUrccqipJK6/fAI9tL/8A+ApNlczjO4tIfXY1sHp7+aK2Gu8qwIbdhSRJ6gsTR0laee1JszYfwCuAo4G/AHt0FZB67Vjg6e3lrwPfo3n9HN1ZRJKk3nCoqiSthJKsCnwWeGFVXdN1PJpb2iU59gDWAQ6pqoUdhyRJ6piJoyStpJKcS1Mcx+U3NFb7RcNPgEf5RYMkaRSHqkrSyuuDwL5JVl/qnppoVXUDsC2eF0iSpmGPoyStpJKcCWwK3ABcCBQQoKpqqy5jU/8k+Q9gN+AtwFk0rxcAqurGruKSJPWDiaMkraSSPHi6bVX18+m2aTIlmUoOB08Mpr5oWLWDkCRJPbJa1wFIklaYh0/Tfk2SbYDvV9X5sxiP+s21GiVJ07LHUZJWUkm+DDwZ+C1wJrAlcF/gKGAL4O7AU6vq+50FKUmS5gR7HCVp5bUK8MyqOmKqIcnuwB5VtUuSvYF3AyaOIsmhLD5Mdco1NHMev1lVJ8xuVJKkvrB6miStvB4FHDnU9m3gMe3lLwDbzWpE6rP5wO408xrPan8/kaa40l2AXyXZq7vwJEldssdRklZe/wReAnxsoO3FbTvARsCVsx2Uemt74LFV9YuphiT3B/arqkckeTTwIeCQjuKTJHXIOY6StJJKci/gcGBV4Gxgc5reo6dU1f8l2Q24U1Ud1GGY6okk84ENq+r6gbbVgYuq6rZJAlxRVWt3FqQkqTMmjpK0EmtP/HcBbgecC/yqqq7rNir1UZKfA78G3lJVVye5NfBW4AFVtVuS7YCfuQaoJE0mE0dJkkSSbYEvAjsDlwAbAMcDz6mqfyXZGdi0qr7dYZiSpI6YOEqSpJsk2ZK2h7qqzug6HklSP5g4SpIkkvyhqnYa0X58Ve3cRUySpP5wOQ5JkgRwh+GGtiCOS7ZIklyOQ5KkSZZkanmNNQYuT9kGOHF2I5Ik9ZGJoyRJk+2f01wu4BfA12Y3HElSHznHUZIkkeRRVfWDruOQJPWTcxwlSRLAte2SHCTZNMnBST6XZNOuA5Mkdc/EUZIkAXwCuKG9vD+wOnAjcGBnEUmSesOhqpIkiSSXV9W6SVYDzge2Bq4FzqmqjbqNTpLUNYvjSJIkgMuTbALcDfhrVS1IsgZNz6MkacKZOEqSJICPAr8D1gBe0bY9EPhbVwFJkvrDoaqSJAmAJNsDN1TVPwf+vlVV/bnbyCRJXTNxlCRJkiSN5VBVSZImVJKTquou7eUzgZHfJlfVVrMamCSpd0wcJUmaXC8YuPyczqKQJPWeQ1UlSRJtBdXnAjsCaw9uq6q9OghJktQj9jhKkiSAg4F7AkfRrOMoSdJN7HGUJEkkuRTYtqou6zoWSVL/rNJ1AJIkqRfOAG7VdRCSpH6yx1GSpAmV5GEDf+4E/DvwYYaGqlbV0bMZlySpf0wcJUmaUElOncFuVVXbrfBgJEm9ZuIoSZIkSRrLOY6SJEmSpLFMHCVJkiRJY5k4SpIkSZLGMnGUJEmSJI1l4ihJkiRJGuv/A6Omrx01Zti5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-14 21:55:49,902 - matplotlib.legend - WARNING - No handles with labels found to put in legend.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3sAAAJwCAYAAAAwfXiUAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABooElEQVR4nO3dd5hkZZn38e+PZAIkDQhINGFOiGkFc845Yo7ruoZdfd01gDmtaTGBqIgRFAOYs5jFwCqiKJIFHHIUEO73j+c0U/R0DzPTM3WqT30/11VXVz/nVNXdp6vqPPd5UqoKSZIkSdKwrNN3AJIkSZKkNc9kT5IkSZIGyGRPkiRJkgbIZE+SJEmSBshkT5IkSZIGyGRPkiRJkgbIZE9Sr5I8LUkluftqPv7u3eOftkYDmwJJ9uqO3Y7T+PrTJMk9kvwsyfl+XibPXJ+FVf1uTHJ8ku+vpfi+n+T4tfHcktYukz1pio0kSpVkn3n22TLJpd0+3x9ziNK8kmzSVZLv3ncskyzJpsAhwHWAlwFPAX7Ya1CaOEle7EUAaXjW6zsASRPhH8ATk7ysqi6Zte0pQIB/jj8saYU2AV7b3f9+f2FMvDvQjtUzq+qQnmPRyjsQ+Axw6Zhe78XA8cDH5th2X9p5QNIiY8ueJIAvAJsCD5tj29OBrwKzk0BJVyPJRquzbU29Rud63c+z1sTrjbzuukmuvSafc+S5k2TDtfHci0VVXV5V/6iqKyYglkvnuBAoaREw2ZME8Gvg/2iJ3ZWS7AbcHPjofA9M8vAkP05yYZILuvtzJY0keXaSPya5JMlfkryYea4WJ7lukrd2+12SZGmSTyfZeXX/yJFxMTdL8u4kpya5KMl3ktyk2+eRSX6d5OJuDMxz5nmueyf5ZpJzkvwjyf8led4c+903yWeT/LV7znO6x+0xx77f715zm+5vPbuL7xtJbrySf+MuSd6f5KhufNZFSX6V5FkreNh1krw3yWldjD9Pcq85nvtBSX6Q5IxuvxOTHDI7tiS3SvKFJGd2x+YPSV6eZN2ViP9jSWqebZXkY939uwPHdZteO9Id+fhZj3lckh+NHIufJ3n01cUx8vgkeX53DC/q3uPfS3KPWfvt2L3+Xt1r/irJxcD/jsae5F5dPBcAh448fqU+R9374/tJbtu9L86lfXbni/944IDu1+/NHKeR7VskeV+Sk9K6a5/U/b75rOeZGT927ySvTnIsrUfAY1fiGD6qi/mc7hj+qXu/bdBtv3LcbZJ/TfKH7rn/o9u+XpJXdO+jf3Tvqy8kueUcr7Vnkl90r3Vh97n7ZJIlI/vcPMnBSU5J+245rfufPuhq/o4HdHG+aJ7tP037nlq/+3237n9+TPd3n9/9Xx9xdcese/ycY/aSbJfkoCTnJjkvyaFJbjDPczwuyZfTPquXpH12v5jkVrP2K2AHYI+Rz9KVYwgzz5i9JLsn+VYXy8Vp353PnGO/BX+3SVo9duOUNOMjwDuTbFtVp3RlzwD+Dhw21wOSvAB4H/BH4HVd8dOALyZ5blXtO7Lvi4F3AUcC/wVcm1aZ+/scz3td4CfA9l1cRwFbAy8Afp5k16o6YQF/6wHABcCbgCW0cUzfSPJq4G3AB7rXfSbwoSR/qKofjcT3HOCDwM+ANwIXAvcBPpDkBlX1nyOv9TRgM+DjwMnAtsCzgO8kuUdVHT4rtuvQxlP9jHacdgL+HfhSkltU1eVX87fdHdid9j87rnu+xwD7JVlSVW+e4zEfBy4H3gpsBDwX+HqSB1TVt7u/eQ/gy8DvgTcD5wDbAPcGbggc0+23K/AD4DLae+M04CHdc98aeNLVxL+yjgZeQntPfYE2Jg3a/5UuljcA/w18HXg1cAXwCODgJC+sqvetxOscCDwB+Bztosc1ur/hW0keWVVfnrX/w4EX0d5DHwTOG9m2K/AoYD+WJWCr9DnqbA98FzgY+DywohawFwMPAJ5De78fPfK6M5+zG9Le778Gbgs8H7hnkt2q6vxZz/cOYP3ubzgP+NMKXpskb6S9j/9A+1+dCtygOw6v4apdFF8MbN4992nASV35J2lJ5bdox/V6wL8CP01yt6r6TfdaT6Ed18O7574Y2A54ILAlsLRLYr/bPe8HgROALWj/mzsCX1nBn/PNLq49gffO+jtvBNwJeG9VXdYVPwLYBTioe53NgacChyR5UlV9agWvNackm9C+H7br4v8DsAfwPeBaczzkhcCZwL5d7DegvRd+nOR2VfXnbr+n0P4/Z9C+02YsXUEsD6F99k4D/gc4H3g88OEkO1fVf896yEK/2yStjqry5s3blN5oiUHRkq7NaV01/6vbdi1ahf4d3e8XAN8feeymXdlfgI1HyjcGjqWd+DfpyjahJUR/AK49su/1u+co4O4j5e+hVdRuPSveHWgVzI/N8Tc8bSX+3r26fQ8FMlL+oq78PGC7kfIltBaGT4+Ubd2VfWqO538PLWnaeaTsOnPstxWtUvXVWeXf7+J4+azy/+zK77cSf+Ncr7dO99znAuvPcTx+Dmwwx//l6JGyd3b7bnk1r/9j2vjOW42UhVbhLeBec7z+jiNlH2unpjmfu2b973fsyvaaY9/bddveNMe2L3b/642u5m95RPccz5lVvh5wBC2ZzqxYLgNuOk/sBdx7VvlKf4668uO753nWKnzOn8asz1hX/sau/AWzyv+1K3/9HM/xJ0Y+w1fzurt1j/kucM1Z2zJy7O7e7XfW7PcX7SJKAZ/lqp/ZW3fvs8NHyg7p/q/rrSCmh3bP99iVPX6zHv/27vE3m1X++q78dlfzWbx2dwz/MKt8rs/Ccv83WsJewNNnPf7dXfn3Z5XPFcNNad/1759Vfvzsx49s+z5w/Mjv69IS2HOAbUbKN6B9B1wO3GjW4xf03ebNm7fVu9mNUxIAVXUmreXmaV3RI4Hr0q74z+U+tCu1762qK1svuvvvpbU23Lsrvi+tkvO+qrpoZN+TaVftr5QktJaTHwKnpHUz2yLJFrSE8Wfd8y3Ee6uqRn6faV37clXNtCZQVUtpFbMbjez7aFrrzv6jsXXxHUpLrO498hwXjvxtG3YtC5fTEqw7zhHbFcxqNWBZS8SNuBqzXu+a3ettRmuV2JjW0jDbu6rqyhaWkf/LLklu2hWf2/18VJI5e4Uk2RK4C+04Xtm1sDvWM60FK9WFbQ14Eq0SecAc/6cv01ow73w1z/FkWrL1xVmP34T2v96R5f8nX6mqo5nbkdW1lI5Ylc/RjLNYQdfqVfAIWsvN7JbDD3Xlc/2vPjD6Gb4aM624r6yqf4xuqM6s/T9eVbNb+mdieOPo/lV1JO1/8C8jXTTPpX3PPKj7HpnLzPv4AUk2Xsm/Y9RMi+yeMwXdaz0Z+H1V/XokxtHP4rW7z+K1aZ/nm67m6z8cOJ3WGj/qrXPtPBNDmo279+/M99pc3z8r6/Z0PS+q6m8jr3cprXfEOiw/BnxB322SVo/dOCWN+ijwlST/QuvC+Yuq+sM8++7U/Txqjm0zZTvP+vnHOfad/fxLaK2M92X+LkQLnbDgr7N+P7v7edwc+55Na1GcMZP8zK60j9pq5k43luaNwP1oScKo2ZVdgL/NrhjTumFBOy4rlDapxV60bm/bzbHLpnOUzZWczPxfdu6270OrvL0feGuSH9G6R366S4phxe+Jo2n/t9Uec7mKbkprPZrrPTdjqxVsm3mOjWiV6xU9xzEjvx8z347zbFuVz9GMY2vNdHnbCTiiqq4y025V/TPJMbTW0dlW9PfNdiPae/zIldx/vuNzBXO/R4+iJT870b4r3kTrwvxF4MwkPwC+Bny2uu6oVfWDJB+nXdR6UpJf0j7Ln535rksbW7qEq7q4qs6tqt8n+XX32P+qNnnK7rTE/+WjD+gufryB9rnZco74N+Gq3XxXxs7AL2f//6vq1CTnzN45yW1prY53p11UGDXX993KWp337YK+2yStHpM9SaO+AZxCm87+HrSxO+M2c0X+28xztXoNmK+iPF955ri/J2380Vz+ClcmXj+kVbLeDfyO1lJ0BfBK4J6rEMPsOObzKeDBtNaaH9IqU5fTxi29hNWcmKuqzkxyB+ButNao3WljfPZO8sCq+unqPO9cLzVX4XytiSuQ7rkewPzHdK6K6uznWAo8cQX7/H7W7ytq9VrZFrGrs6aeZxyvPdN9dW0891VfqOrPSW4G3Ku77UEb/7d3kt2r6thuv6cmeTvtvXE32pjd/07y4qrah3aRZHYidADLej18nPZ5vifte2pP2nvsEzM7d61936RdMHgPrdvvud1+T6e9p9Zq76ok29O+A86jJXx/ovWOqC7+cc92utDvNkmrwWRP0pWq6vLuqvcraWPmPr2C3Wdax24OfGfWtpvN2mfm5y4r2HfGUto4kI3n6PI2CWYmNDhjJeK7F20Sk2dU1VW63XWTh6xR3eQNDwYOrKrnzdo2uyvgqJuyfOvL7P8hXWvC97sbaTP6/Qp4FfAgllWQbz7Ha+xCq9zOblWd7azuuTerqtGlAuZqEVxREvFn4P7AiSvoVnl1/gzcGPhZVV1wdTuvplX5HK2N175JkvVGW/e6xPrGa+B1j6ElVLcGfrGAGNehvUdnzzo6c3yuTMyqLQ/w1e5GkgfSJl15KW0s4sx+v6cl6m/vPjc/B96SZGZSofvMeq2/jdz/FG3s3p5Jfkzr2v2tqhq9+HMr2t/9uqp67egTZcUz416dvwI3SrLuaOtekq1ZvufAI2gJ3UOr6nuzYpgZoz1qZZPymThg7s/62n7fSloFjtmTNNsHgb2B542OIZrDt2hXif8tI+t8dff/jTbpxLdG9r0Y+NeMrMuV5PrMajXpukV9Etgt80yR33WP6stBtErS3kmWm/0ubcmIa3S/zlTGMmuf+7Kw8TLzme/1tqbNADqfl6SbBr/bf+b/8qeZRKkb6zPbH2n/180AuvFWPwEekuQWI88X2gUEaLP3rchMV77ZyenL5th3JgHbbI5tB3Y/35Q5lnxIcnVdOKG14KxDm310OSv5HFdnVT5Ha9oXad0VZ783nt2VX93/6urMzDb5ptH314wVjKsb9cXu5ytH9+/eXw8FfjTTjXie9+jMGLrNun02S3KVuk9VnUNLGK9Nm0jmH1X17Vm3P4zsv5TWPfSRtHGJGzMyu2pnvs/iLVjYuNUv0boO7zmr/BVz7DtfDM9m2dqLoy5g7s/SXH4NnAg8PcmVz5W27MTMpCtfWsnnkrQW2bIn6Sqq6kTamK+r2++cJC+nTRn/83Trn9G6Ot0QeG5Vndvte3basgbvAH7StR5eG3gerfXktrOe/r+BuwIHJTmINinLpbSxcw+ktSY9bbX/yAWoqpOTPB/4MHB0kgNps9ItAW5JG0N0M9rMdj+im5Y8bb2qk4Hb0KY5/123/5qM7fwk3wSenLbG2y9px+y5tMrsfONi1gMOT/Jp2hi159FmYx1dT2y/Lgn8Ju3vvRbwuG7/0cki/p229MLhI60kD6aNWfxUVc1uvZrt07SxV/sm2YXW0nd/2vT4s//eM5P8BXh82rpvpwMXVtWhVfXLJHvR3su/TXIwrXVma9rkEg+kzRw4r6r6XJKPAi9McjvachZn0GYrvTPtfb6gMYir8jlaC95GW5bjfd3f9xvaZ/GZtC5/b1vIk1fVL5K8lZaI/DrJZ2nvh51orWG70VrxV/Qc3+q+Ax4PbJrkMJYtvfAPrvoe/WY3bu1w2rINm7BsRsuZ5H9P2sWNL9BmQL2M1t3zfsBBVXXxSv55B9CSzf+hdc/84qztR9O6Cb+8u8D1J1pr6XNpn/3br+TrzPY22oWY/ZLcvnuNu9Pej2fM2vdrtK6xBybZhzb++K609/6xLF8H/BnwzCSvZ9kY20NHJ5qZ0fUCeSHtgsAvk+xL66L+ONoSFG+qZcs6SOrT2pji05s3b4vjxsjSCyux71WWXhgpfwStNefC7vYT4OHzPMdzaZWeS2gVrRfTxq/MNS38tWlro/2O1np0Pq0Csh9wxzn+hqetxN+wF7OmN+/Kd2T+Kfy/z8iU4yPld6VVdP5OS0T/Rlvr6mWMTDNP6871dVpF6/zu+e7GHEsMrOC15o1vjn23oCWif6NVhn9Ha6l52uzjPHI8bk5b/Pu07jG/AO4z63kfSZvF8uTu/7eUltQ9ao4Ybk2r/J7V7Xs0bfKKdVfy/3FH2vTt/6BVYPelVdyLkaUXun136/adGYt0/KztD6KNRZ2J5SRaJfh5q/A5eQotgTivi+l42jT/j1vZ/9Fcsa/O54gVTI+/gude7n8/sm0JbdKdk2mJz8m0xHOLlX2OlXj9J3T/o/O7v+2PtDFjG6zMZ5iWlLyiex9d0v0vvwjcctZ+z6a1gp5G+0yeSuvOeY+RfW5DS9T+0sVyHq0L88uAa6zC37QBbTxsAfvNs88OtLUQl9KSrl90/+fl3vfzlM15zGmzYH6ui/082qykN5jrvUEbW/uj7tifQ+vSegvm+K6hTSLz+e74XjEaz1z7d+V7dMd85rPxG+CZc+w33+N3ZCW/27x587Z6t5k1biRJkiRJA+KYPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRqg9foOYKG22GKL2nHHHfsOQ5IkSZJ68atf/eqMqloyu3zRJ3s77rgjRxxxRN9hSJIkSVIvkpwwV7ndOCVJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmAFv1snJIkSZK02FxxxRWcccYZnHPOOVx++eXz7rfuuuuyySabsMUWW7DOOqvWVmeyJ0mSJEljdvLJJ5OEHXfckfXXX58ky+1TVVx22WWcfvrpnHzyyWy//far9Bp245QkSZKkMbvwwgvZdttt2WCDDeZM9ACSsMEGG7Dtttty4YUXrvJrmOxJkiRJUg9WtlvmqnbfvPJxq/UoSZIkSdJEM9mTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpB5U1RrdbzaTPUmSJEkas/XXX5+LL754pfa9+OKLWX/99Vf5NUz2JEmSJGnMttxyS0455RQuuuiieVvuqoqLLrqIU045hS233HKVX2O9hQYpSZIkSVo1G2+8MQB/+9vfuOyyy+bdb/3112errba6cv9VYbInSZIkST3YeOONVyuJW1l245QkSZKkATLZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBWq/vACRJkiRpoU5/z0/7DmGt2urf77zKj7FlT5IkSZIGaKzJXpJPJDk1yXlJjknyrDn2eU2SSnLvccYmSZIkSUMy7pa9NwM7VtXGwEOBNyS5/czGJDcAHgOcOua4JEmSJGlQxprsVdVRVXXJzK/d7QYju7wPeAVw6TjjkiRJkqShGfuYvSTvT3IR8EdaC95Xu/LHAJdU1VdX4jmek+SIJEcsXbp07QYsSZIkSYvQ2JO9qnoBsBFwN+AQ4JIkGwFvAv59JZ9j36ratap2XbJkydoLVpIkSZIWqV6WXqiqy4EfJXky8HxgB+DAqjq+j3gkSZIkaWj6XnphPdqYvXsBL0pyWpLTgO2Ag5K8otfoJEmSJGmRGlvLXpItgXsChwEXA/cGntDdXgesP7L7L4GXAl8bV3ySJEmSNCTj7MZZtC6bH6S1KJ4AvLiqvjx7xySXA2dX1QVjjE+SJEmSBmNsyV5VLQX2WMl9d1y70UiSJEnSsPU9Zk+SJEmStBaY7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAJnsSZIkSdIAmexJkiRJ0gCZ7EmSJEnSAI012UvyiSSnJjkvyTFJntWV3ynJt5KclWRpkoOTbD3O2CRJkiRpSMbdsvdmYMeq2hh4KPCGJLcHNgX2BXYEdgDOBz465tgkSZIkaTDWG+eLVdVRo792txtU1UGj+yXZB/jBOGOTJEmSpCEZ+5i9JO9PchHwR+BU4Ktz7LY7cNQc5TPP8ZwkRyQ5YunSpWspUkmSJElavMae7FXVC4CNgLsBhwCXjG5PcivgNcB/ruA59q2qXatq1yVLlqzNcCVJkiRpUeplNs6quryqfgRcH3j+THmSGwJfA/69qg7vIzZJkiRJGoK+l15YD7gBQJIdgG8Dr6+qA3uNSpIkSZIWubEle0m2TPL4JBsmWTfJ/YAnAN9Jsi3wXWCfqvrguGKSJEmSpKEaZ8te0bpsngycDbwDeHFVfRl4FrAzsFeSC2ZuY4xNkiRJkgZlbEsvVNVSYI95tu0N7D2uWCRJkiRp6PoesydJkiRJWgtM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYDGts6eJEmSpIU7/t2n9R3CWrXji6/XdwiDYcueJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDdBYk70kn0hyapLzkhyT5Fkj2+6V5I9JLkryvSQ7jDM2SZIkSRqScbfsvRnYsao2Bh4KvCHJ7ZNsARwCvBrYDDgC+OyYY5MkSZKkwVhvnC9WVUeN/trdbgDcHjiqqg4GSLIXcEaSXarqj+OMUZIkSZKGYOxj9pK8P8lFwB+BU4GvAjcHjpzZp6ouBI7tyiVJkiRJq2jsyV5VvQDYCLgbrevmJcCGwLmzdj232285SZ6T5IgkRyxdunRthitJkiRJi1Ivs3FW1eVV9SPg+sDzgQuAjWfttjFw/jyP37eqdq2qXZcsWbJ2g5UkSZKkRajvpRfWo43ZOwq49UxhkuuMlEuSJEmSVtHYkr0kWyZ5fJINk6yb5H7AE4DvAF8AbpHkUUmuCbwG+D8nZ5EkSZKk1TPOlr2iddk8GTgbeAfw4qr6clUtBR4FvLHbdkfg8WOMTZIkSZIGZWxLL3QJ3R4r2P5tYJdxxSNJkiRJQzbWdfYkSZKklfW1z57Rdwhr1QMet0XfIWjg+p6gRZIkSZK0FpjsSZIkSdIAmexJkiRJ0gA5Zk+SJGkCvOgLJ/Udwlrz3kds13cI0lSyZU+SJEmSBshkT5IkSZIGyGRPkiRJkgbIZE+SJEmSBshkT5IkSZIGyGRPkiRJkgbIZE+SJEmSBsh19iRJ0lg9/HPf6TuEteqLj75X3yFIEmDLniRJkiQNksmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkBO0SJK0ljz4c5/sO4S16rBHP6nvECRJK2DLniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQNkMmeJEmSJA2QyZ4kSZIkDZDJniRJkiQN0Hp9ByBJWvwe9IW39x3CWvWVR/xn3yFIkrTKTPYkaRU9/Qv37zuEteajj/h63yFIkqQ1xGRP0rw+dOD9+g5hrXruU77RdwiSJElrjcmeBHxj/wf2HcJadb9nfrXvECRJkjRmK5XsJXkT8Iaquqj7/YHA96rq4u73jYF9qmrPtRap1ogT3/vovkNYq7Z/0ef6DkGSJEmaCCs7G+crgA1Hfv8MsPXI79cCnrSmgpIkSZIkLczKJnu5mt8lSZIkSRNk0GP2ln7gE32HsNYsef6T+w5BkiRJ0gRzUXVJkiRJGqBVadl7XpILRh73zCRndr9vtGbDkiRJkiQtxMomeycCTx/5/TTgiXPsM68k1wDeD9wb2Aw4FnhlVX2t2/5YYG/g+sBJwH9V1RdXMj5JkiRJ0oiVSvaqasc19FonAXvQEsMHAgcluSVwGfAJ4GHA17ttByfZsar+vgZeW5IkSZKmyhoZs5fkOkmetaJ9qurCqtqrqo6vqiuq6jDgOOD2tNa8c6rqa9V8BbgQuMGaiE+SJEmSps2Ckr0kd07yYVq3znev4mO3Am4MHAUcARyd5KFJ1k3ycOAS4P8WEp8kSZIkTatVTvaSbJ7kpUn+APwI2BJ4ZvdzZZ9jfeCTwAFV9cequhz4OPApWpL3KeC5VXXhPI9/TpIjkhyxdOnSVf0TJEmSJGnwVjrZS3K/JAcDJwMPBd4JXAH8v6o6qKouWsnnWQc4ELgUeGFXdm/gbcDdgQ1o4/o+nOQ2cz1HVe1bVbtW1a5LlixZ2T9BkiRJkqbGSiV7SY4H3gP8FrhpVd29qj68qi+WJMD+wFbAo6rqsm7TbYAfVtUR3Xi+XwI/p83cKUmSJElaRSvbsnc94EhasnfSAl7vA8BNgYdU1cUj5b8E7jbTkpfktsDdcMyeJEmSJK2WlU32tqdNovIO4G9J3pPkDkCt7Asl2QF4Lq0V77QkF3S3J1XVD4C9gM8lOR/4PPCmqvrmyv8pkiRJkqQZK7vO3t+BtwNvT3I34BnA97rHPzfJvlV11NU8xwlAVrB9H2CflQ1ckiRJkjS/VZ6Ns6oOr6qnA9sALwDuDPwuydFrOjhJkiRJ0upZ7XX2quq8qvpgVe0G3Bqwy6UkSZIkTYiV6saZ5MtrOxBJkiRJ0pqzUske8GDgBOD7ay8USZIkSdKasrLJ3tuBpwC7Ax8FPlZVJ6+1qCRJkiRJC7JSY/aq6hXAdsBLgF2BPyf5WpJHJ1l/bQYoSZIkSVp1Kz1BS1VdXlVfrqqHAzvRll54A3BKkg3XUnySJEmSpNWwurNxXgfYBNgQuIBVWFxdkiRJkrT2rXSyl+RaSZ6a5IfA74AdgKdW1c5VdeFai1CSJEmStMpWdumF/YDHAn8G9gceWlXnrMW4JEmSJEkLsLKzcT4TOBE4FXgA8IAky+1UVQ9dc6FJkiRJklbXyiZ7H8dxeZIkSZK0aKxUsldVT1vLcUiSJEmS1qDVnY1TkiRJkjTBTPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmATPYkSZIkaYBM9iRJkiRpgEz2JEmSJGmAxpbsJblGkv2TnJDk/CS/TfKAke3XTvL+JGckOTfJD8cVmyRJkiQNzXpjfq2TgD2AE4EHAgcluWVVHQ/s2+1zU+As4DZjjE2SJEmSBmVsyV5VXQjsNVJ0WJLjgNsnuSbwUOD6VXVet/1X44pNkiRJkoamtzF7SbYCbgwcBewGnADs3XXj/F2SR/UVmyRJkiQtdr0ke0nWBz4JHFBVfwSuD9wCOBfYBnghcECSm87z+OckOSLJEUuXLh1X2JIkSZK0aIw92UuyDnAgcCktqQO4GLgMeENVXVpVPwC+B9x3rueoqn2rateq2nXJkiXjCFuSJEmSFpVxTtBCkgD7A1sBD6yqy7pN/zfH7jW2wCRJkiRpYMbdsvcB2mybD6mqi0fKf0ibofOVSdZLclfgHsA3xhyfJEmSJA3CONfZ2wF4Lm1JhdOSXNDdntS18D2MthzDucB+wJ7deD5JkiRJ0ioa59ILJwBZwfajgDuPKx5JkiRJGrLell6QJEmSJK09JnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEAme5IkSZI0QCZ7kiRJkjRAJnuSJEmSNEBjS/aSXCPJ/klOSHJ+kt8mecAc+70mSSW597hikyRJkqShGWfL3nrAScAewHWBVwEHJdlxZockNwAeA5w6xrgkSZIkaXDGluxV1YVVtVdVHV9VV1TVYcBxwO1Hdnsf8Arg0nHFJUmSJElD1NuYvSRbATcGjup+fwxwSVV9dSUe+5wkRyQ5YunSpWs5UkmSJElafHpJ9pKsD3wSOKCq/phkI+BNwL+vzOOrat+q2rWqdl2yZMnaDFWSJEmSFqWxJ3tJ1gEOpHXVfGFXvBdwYFUdP+54JEmSJGmIxprsJQmwP7AV8KiquqzbdC/gRUlOS3IasB1t8pZXjDM+SZIkSRqK9cb8eh8Abgrcu6ouHim/F7D+yO+/BF4KfG2MsUmSJEnSYIwt2UuyA/Bc4BLgtNbIB8Bzq+qTs/a9HDi7qi4YV3ySJEmSNCRjS/aq6gQgV7tj23fHtRuNJEmSJA1bb0svSJIkSZLWHpM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRqgsSV7Sa6RZP8kJyQ5P8lvkzyg23anJN9KclaSpUkOTrL1uGKTJEmSpKEZZ8veesBJwB7AdYFXAQcl2RHYFNgX2BHYATgf+OgYY5MkSZKkQVlvXC9UVRcCe40UHZbkOOD2VfX50X2T7AP8YFyxSZIkSdLQ9DZmL8lWwI2Bo+bYvPs85TOPfU6SI5IcsXTp0rUVoiRJkiQtWr0ke0nWBz4JHFBVf5y17VbAa4D/nO/xVbVvVe1aVbsuWbJk7QYrSZIkSYvQ2JO9JOsABwKXAi+cte2GwNeAf6+qw8cdmyRJkiQNxdjG7AEkCbA/sBXwwKq6bGTbDsC3gddX1YHjjEuSJEmShmasyR7wAeCmwL2r6uKZwiTbAt8F9qmqD445JkmSJEkanLEle13L3XOBS4DTWiMfdGU3BHYG9kqy18yGqtpwXPFJkiRJ0pCMc+mFE4CsYJe9xxWLJEmSJA1db0svSJIkSZLWHpM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRogkz1JkiRJGiCTPUmSJEkaIJM9SZIkSRqgsSV7Sa6RZP8kJyQ5P8lvkzxgZPu9kvwxyUVJvpdkh3HFJkmSJElDM86WvfWAk4A9gOsCrwIOSrJjki2AQ4BXA5sBRwCfHWNskiRJkjQo643rharqQmCvkaLDkhwH3B7YHDiqqg4GSLIXcEaSXarqj+OKUZIkSZKGIlXVzwsnWwEnALcBng9sUFXPH9n+e+C1VfX5OR77HOA53a83Af601gO+elsAZ/QdxATyuMzN4zI3j8vyPCZz87jMzeMyN4/L8jwmc/O4zM3jMrdJOi47VNWS2YVja9kblWR94JPAAVX1xyQbAktn7XYusNFcj6+qfYF9126UqybJEVW1a99xTBqPy9w8LnPzuCzPYzI3j8vcPC5z87gsz2MyN4/L3Dwuc1sMx2Xss3EmWQc4ELgUeGFXfAGw8axdNwbOH2NokiRJkjQYY032kgTYH9gKeFRVXdZtOgq49ch+1wFu0JVLkiRJklbRuFv2PgDcFHhIVV08Uv4F4BZJHpXkmsBrgP9bZJOzTFS30gnicZmbx2VuHpfleUzm5nGZm8dlbh6X5XlM5uZxmZvHZW4Tf1zGNkFLt27e8cAlwD9HNj23qj6Z5N7APsAOwM+Bp1XV8WMJTpIkSZIGprfZOCVJkiRJa8/YJ2iRJEmSJK19JnuSJEmSNEAme6spybpJjk1yjb5jmRTdMTnAY6KV1S3FImk1dN+5r/M7Vyuje7983/fLMknWSXLPJBv0HYsm32Kt+1vRWk1VdTlwOXDNvmOZFN0xuS9wRd+xTBpPsstLsi5wocfkqnyvaGV137kvAC67un2nVZLtk9w5yfZ9x9K37v2yE9b9rlRVVwBfqqpL+45l0nguWt5irfv7gV+YdwMHJdkjyQ2S7Dxz6zuwHr0L2DvJ+n0HMkk8yS6vOybHAJv3Hcsk8b2yYknWT3K3JI/rfr9OtzbrtPo48Ly+g5g0SbZO8gPgL8AhwF+S/DDJNj2H1re9gQ8k2aGrzK8zc+s7sB79MMmd+g5i0ngumte7WWR1f2fjXIAk87VgVVWtO9ZgJkSSk4Dr0a58LAWufINV1VRfWU3yDGB34LXAyVz12Exla2iSlwOPB97D8sfku33F1TffK3NLckvgy7QlfK5fVRsmeSDw1Kp6XL/R9SPJj4A7AqcAJ3HV98rufcXVtyRfBE4EXllVF3YXBN4E7FRVD+01uB6N1FtGK39huust7weeAHyJ5T9Dr+krrknguWh5i7Hub7KnNSrJHvNtq6ofjDOWSeNJdnlJjptnU1XVxF4lW9t8r8ytS2w+VFUHJjm7qjbtKvHHVNW2fcfXhyRPnW9bVR0wzlgmSZIzgK2r6rKRsmsAp1TVFv1F1q9uzeM5VdUJ44xlUiT56DybqqqeMdZgJoznomEw2VsDurEA2wInV9VJfcejyeRJVivL98rckpwNbFZVleSsqtqsK7/y/rRJsm7X3UojkvwZeHRVHTlSdivgkKq6YX+RTYau2+ZWwOnT2kKjq+e5aH6Lqe6/Xt8BLGZJtgY+A9wZOBPYPMnPgMdX1d96Da4n3Vi9VwFPAbYB/gYcCLxx2gdAz3wxepK9qiTrAXeh+9IEflpV/+w3qt5tWlW/7TuICXQ8cHvgiJmCJLvRxmVNq9OSHAx8sqp+3HcwE+RtwLeT7A+cAOwAPB14da9R9SzJxsA+tO7z6wGXJfkM8KKqOrfX4HqU5Ea0rpzb0rpEf7qq/txvVP2z3rK8xVj3d9DlwnwAOJJWMdsa2BT4DfDBXqPq19uAe9MmDLh19/OewFv7DGoSJNk4yceBf9BOJhd3S1Vct+fQepNkF+Bo4FPAi4BPA39MctNeA+vfN5McleRVkzzouwevBr6SZG9ggySvBA6mXWCaVvcFLgA+neS4JG/uxjZOtaraD3gcsAXwkO7nE6tq314D6997gesAtwCuBdwSuHZXPpWSPAT4FbALcBZwE+CIJFM7tnOG9ZY5Lbq6v904F8AxActLcjJw66o6c6RsC+DIaR1TMyPJx4CNgFey7ErzG4GLqmrecTdDluS7wNeAd1T3ZZTkP4AHVdU9eg2uR92yFPenXWl+KHAULSH+bFX9vc/Y+pbktsCzaZ+fk4D9qupX/UY1Gbox008AHgWcWlW36jkkTZgkpwE7V9VFI2UbAsdW1Vb9RdafJL+jtWx+b6Ts7sA+VXWLvuKaBNZblrcY6/4mewvgmIDlJTkFuNUcyd7/VdVUT3ntSXZ5Sc4CloyOOeq6dS6tqk37i2xyJLkW8DDg+cCdqso1jzSnJFvRuuftCdyoqjbuOaTeJHkp8N2q+m2SO9JagC+nte79tN/o+pPkeGCP0fFWSXYEfjitM2Z3Y4GXjA4f6M5DZ1TVJr0FNgGstyxvMdb9HbO3MI4JWN7BwKFdN6sTacfkVcBBvUY1Gf4BLKG9V2ZsQZtGflr9DdgDGF1m4W5d+dRLck3gwbTuaLsCh/cbUb+SvG6eTZfQxnt+vapOH2NIvUuyCa0l74nAnYBv0rrNf7nHsCbBS4D9u/tvAd4JnE9bI+uOPcU0CT4MfCvJO1lWb3kJMM3dW38LvIyrDjd5aVc+7ay3LG/R1f1t2VugJPeknWRnJiP5dFV9p9+o+pNkA1pyd5VjAryhqqb5y4Ekr6JdcZ99kj2wqt7QZ2x96cZEfAo4jHZMdgQeCDy5qr7UY2i96taOeyKtC+cfaIPBP1NVp/UaWM+6iSQeAfyC1oVzO2A34FDg+rTxR4+qqq/3FuSYJbkI+Ante/bzVXVOvxFNhiTnVdXGSTaifbcsqarLk5wzza01SUKrmM4+R3+kprRC2I0dP5Q2lvEkYHvgQuAhVXV0n7H1zXrL3BZb3d9kTxoTT7JzS3Jj4LEsOyYHVdUx/UbVryR/oL03PlVVx/Ydz6RIchDtpPqFkbKH0brmPa5bc+4lVXWbvmIctyRPBH5WVX9Ncj1a68QVtMXEp/biQJKjaGM7b04bA/zwbibK46pq836j06Tpum3eiWXnoZ+PjsmaVtZbhsFkbwEcE7C8JPcAjq+q46x4aFV149OumPZWYM0tybm0dfZGx3iuC5zdteJceb+3IMcsydHA/arqxCSf6oovprVkTe1sgl3r+IeBS2mtvb/qEuOnVNUD+o2uP0meAPy2qo7uLrTtRztHP7+q/thvdJOhq8dcUVU/6DsWTZ7FWPd36YWFeQlwXHd/ZkzAG2hjAqbV+2lvemjHY33aiWSaxwMA7SQ7s6RAkhsn+UGS73VdSKZSknekrZNGkgfRpr0+u5sKe2oleWmS23T375TkxG5a/Tv3HFrfjqVNVDPqeV05tLEkFzFdtu0SvfWA+wHPoR2ju/QbVr+q6qtVtU1V7TgyW+vBtK7R0+wNtO9ZgP8Bfgn8gHbunkrdufiu3f1X0LrNfyrJf/UbWf+st8xp0dX9bdlbAMcELG/kmKwHnE7r330p8LdJnZJ2XJIcC9ylqk5PcijwJ9r6WLtX1T37ja4fSU4FblBVFyX5OW3g87nAu6pqatcKS3IScIuqOjfJ94Av0SaXeE5VTe3kEkluBxwCrEtb82lb2sWlR1bVr5PsDtykW2NtKqQtd3N72rppe1XV3bqx00uramrXwkpyM+DM7vt2Q+A/aRce3z46s+C0GTlHXxM4FbgecBlt5snN+o2uH0nOBLbs6m9/oV0QOB/48bTOUDrDesvyFmPd39k4F+akJHehjQn4YffP3phlLVvT6Lxu+u9bAH+oqgu6isf6Pcc1CZZ0X5jXBP4FeDTdSbbfsHp17S7R25w2vfPnAZLs0HNcfbtul+htBNwauHf3/fI/fQfWpy6huxFwZ2BrWmX1pzNja6rqh8APewyxD/9La53ZAHhxV3ZXYNq75H2aNhb4dOAdtIWy/wF8CHhKj3H1bWmSG9ImM/plVV2S5NpAeo6rT+sAleQGtEaQPwAkcfkf6y1zWXR1f5O9hflP4HN0YwK6sgfTZoqbVlY85udJdnnHJHkScEPgW3DluowX9xpV/xbdyWRcusRu2hK6eVXVW5N8Abh8ZDKfU4Bn9RjWJNixqv7UTTDxSOBmtO+V41b8sMF7PfAr2nfJ47qyewNHzvuI4fsRsA/tAtIXALrEb5oTmhnWW5a36Or+duNcw5KsD1dWSKZSN+j7yopH9/s1qup3/UbWryRPA95Dd5Ktqm+lLT3w0qq6e5+x9SXJHWjH5FLgmVV1bJf83b+qpvbqe5IH0NYIm/rJJbourVd7opr27la6qiSn0y4i3Qx4X1Xt2g0vOGuaJvCZS1dZZ6Y7a5ItgXWmdRK1rmfJy2gtVm+rqgu7MeQ3qqp39xpcz6y3rJxJr/ub7C2AYwKunrNaXZUnWV2dJOsAd6eNF7lkpHyiTyZrS5I9Rn69A/BU4L0sW/PphcDHq2qqu7jqqpK8i9btbCNgn6rap5sMar+qunW/0fUnyRLg4m6Ixbq0NdSuoK2bdkW/0WkSWW+5qsVY9zfZW4AkRwKP7bqKfJBlYwLOmNZWiSQ/AP6rqn7czWr1UuCftCurb+o3un55kl1errpUx9a0ma2mfqmOJOdX1UZ9xzFpkvyetszAKSNl1we+XlW36C8yTaIk9wUuq6rvdb/vCmxcVd/tN7L+dBNhPa+qfpPkLcBDaC1a36uql/QbXT9y1an07wQcxIRPpT8u1luWtxjr/iZ7C5Dk3Kq6bjcm4HRGxgRU1Zb9RtcPZ7WanyfZ5cU1wuaU5CvA66vqZ33HMkmSnAXsVFXnjpRtQvvOdTIF6WokOZu2VmV1M7nehTa74lFVtXW/0fXD2Y/nZ71leYux7u8ELQvzj262vJsBJ1bVGd2YgGv2HFefnNVqfjcGftvdfzIjJ1naui3TaPYaYVcu1dFvWL07Afhaki8BVxmzVlWv6S2q/n0Z+HKSNwAnA9sBr+zKpSt13ykvAPagrb945YQSVbV7X3FNgMuBDbqx9Od237/rABv2HFefnP14ftZblrfo6v4mewvzKeC7dGMCurLbMd2zfTmr1fw8yS7PpTrmdi3gi9396/cYx6R5HrAX8EFgG9rSCwcBe/cYkybTu4B7AvsCbwT+m7bY/Gf6DGoCfI32mdmcZcfiZrQZXKeVsx/Pz3rL8hZd3d9unAvkmICrmjWr1du7yruzWgFJDgQ2pp1kv1FVr09yC+BzVbVLv9H1oxvX+a90S3VU1We6cXxvmfbuM5JWX5JTgDt3ldNzqmqTJLsAH6qqPa7u8UOV5Bq0SY4uo427+meSuwPXq6qpTISTPBD4MM5+vBzrLXNbbHV/k701IMl2tO5ojq/RvDzJzs2lOubXdRWZ3QXtr/1FNH5Jdq+2WDpJ7jnffpN6klU/Zo1NOxW4QVVdlOS8aV96Aa6c9Xerqjq171gm0bTOfjyb9Zb5Laa6v8neAiTZHvg0cBugqmrDJI+mrRE2lQvadl8MrwGeAGzeDWK9L3DjqtpnxY+eDp5kr6o7qd4J2KaqPpvkOgBVdWG/kfWnm9r5k7TxI0VL9gqgqtbtMbSxS/L7mZk2u4kU/jnHblVVO483Mk2yJD+h9Rb4RZJDgaOB84AnVdVN+42uP92ERu8HHk1rmbhO2rppu1XVq3oNrkddq+9jaOfmF3a/b1BV/9dzaBPBessyi7Huv07fASxyHwK+Quu3O3P151vAfXqLqH/voo2/ehLLJpU4ijZWYqol2aSbcfIfwF+6sod2k01MpSS3BI4B9qMtIg5tQoWP9BbUZHg/8D1gM1oFdVPa981T+wyqDyOJ3rrAEmCXqtpp1s1ET7P9O8vOyy+ljal5MPDs3iKaDB8EzmXZZFgAPwUe11tEPUvyGOBwYFva0gLQxqS9s7egJoT1ljkturq/LXsL0C0zsKSqrkhyVlVt1pWfU1Wb9BtdP7ruMjesqgs9JleV5DPA2cDraJORbNqtYfOTqrpRv9H1I8mPaGNoDkxydndMrgMcU1Xb9h1fX7ouaFtW1WUj442uA/y+qnbqO76+pK1v9ICqmvbZWjWHFXXzHTXNXX6TLKX1orhs1jn63Kq6bs/h9aJbAujxVXXkyHlofeBvVbWk7/j6ZL1leYux7u9snAtzOnBDWssEcGX3qxN7i6h/lzLrfdV9MZzZTzgT5V4sO8nOdMlbmmQi12UZk5sDn+juzxyTC5Ncq7+QJsI/aDOSXgac0XUbOZs2SH6afRI4LMl7aEsvjC5JMbUVeF1p/6vfhQKmuSX4XNo44Cu743XfL9PcPW9LYKa7Zo38tDXEestcFl3d32RvYd5Bq3i8GVgvyROA/wLe0m9YvToYOCDJSwCSbA28G6e7Bk+yczkeuD1wxExBkt3ouotMscOBxwIfAz5Hmy79Etp0z9Nspjv4XrPKp70CL2CaW71XwYeBzyf5b2CdJHcG3kTr3jmtfgU8Bfj4SNnjgV/0E85Esd6yvEVX97cb5wIleRjwXFr/9xNpXdK+2GtQPerWSHsrbVzEtYGLaOOxXlFVl67osUOX5P8BD6Wt9/QF4AG0k+yXpnVZiiQPpl2N/yBtyY430tZSe3ZVfbPP2CZFNzD+ibTxAR+f5olrJC1MkgAvYla9BXhPTWmFsJuM5Zu0ddLuBHyftpj4favqzz2G1jvrLXNbbHV/k73V1E0W8B3gflV1Sd/xTILumLwWeGNVXdJ13zxjWk8gs3mSnVuS29IuDuwAnATsV1W/6jeqyeAMaJLWlO4c/RHgOdZbmu68vBNwBnB/lp2HDquqC/qMbRJYb7mqxVr3N9lbgCQn0GaGu7jvWCZFkjNoE0tc0Xcsk8ST7PK6Y3IMcDOPyVUl2RR4H06PLmkN6iZR237a148bleRCYCPrLVdlvWVui7Hu79ILC7M38IEkOyRZN8k6M7e+A+vRx2nd8DSiqi4H7gt4Mul0x+Ry4Jp9xzKBPoDTo0ta894F7N0NuVDzG1q3TY2w3jKvRVf3t2VvAZLMfABGD2JoiyxO1cLHM7qp9O8InELrCjE6W97ufcU1CZK8HNgE2Gvaxy/OSPIC4GG0MQCzZ1f8a19x9c3p0SWtDUlOAq5Hu9C2lKt+527fV1x96taMezJtQqzZ9ZapXvPVesvyFmPd32RvAZLsMN+2qjphnLFMiiTzLvpcVQeMM5ZJ40l2eSNfmrNN7JfmOCT5C3C3qjp1JtnrZkD7ZlXt0nd8khanJHvMt62qfjDOWCZFku/Ns6mqaqXWbhwq6y3LW4x1f5M9aUw8yWplOQOaJKlv1luGwWRvAZIcyNyLbl5C65L2xao6crxR9SvJM+bZNHNMfuZAX2nFnAFN0tqQ5HXzbJo5R3+9qk4fY0i9m2+slRO2aC6Lse5vsrcASfahLcT5ZVo/7+2Ah9AWEN+EdmX+eVX18fmeY2iSfB+4M3A67U1/fWAr2qLZO3a7Payqjpjr8UPmSXZ5SQ5nxV+ah1TVoeONSpKGKclngEfQFgyfqbfsBhxKO1/fEnhUVX29tyDHrBtOMNd56J/A34BDgNdO41IM1luWtxjr/uv1HcAid2PggVX145mCJHcGXldV90lyf+DdtBkqp8VRtAr6e2cKkrwQ2AX4F1q3tP+lJYTT5sbMf5J9CPD+JFN1kqUtXvtU4ACWHZM9gU/RBjx/JMnbq+ptvUXYkyQ3AW4NbDhaPu0TBkhakHWAx1fVF2YKugWin1hVd+rG3b8FmKbz0L8BD6f93ScB2wMvB74C/Im2fvC7gWf1E16vrLcsb9HV/W3ZW4Ak5wKbV9U/R8rWpy0kft2uK9b5VbXhvE8yMEnOph2TK0bK1qUdk02TXAP4+zTOKJjkIODT85xkH9edZF9SVbfpK8ZxS/Jz4GlVdfRI2S7AAVV1xyS70Y7ZDXoLsgdJ/gt4DXAkcNHIpqmfMEDS6uvqLZt10+rPlK0LnF1VG4/e7y3IMUtyLHC7qjp3pGwT4FdVdYMk23b3r9dXjH2x3rK8xVj3n9g1IRaJ3wJvTHJNgO7n62kVNICdgLP6Ca03p9Ou9ox6EPD37v41gWldzPV+tGb/UYfRJt8A+ASw81gj6t8uwOwlFk4AbgJQVb+gdQOeNi+mLaB+x6q6x8jNRE/SQhwLPH9W2fO6coAtuOoFpmmwMXDtWWXXBmYuSp8GXGusEU0O6y3L+y2LrO5vN86FeSqtu9l5Sc4CNqONTXtSt30z4AU9xdaXFwEHJ/k9y5r8bwE8ptt+R1o3zmk0c5LdZ6Rs2k+yPwQ+muQ1LBvjuRfwI4AktwRO7S26/lwM/LHvICQNzrOAQ5K8grYe7ra0afUf2W2/CfDqnmLry8eBbyV5D63ecn3g32nDC6AtLP6nnmLrm/WW5S26ur/dONeAJNsB2wCnVtWJfcfTtyRb0K76bEOrqH+lqs7sN6r+JbkdbaD3usw6yVbVr5PsDtykqvbrMcyxSrIZ8H5aRWM9WqvvIcC/VdUZ3bi1jaZtQp8kewJ3pSW+Vxn87gxxkhai63J2J5ado39aVdPa42ZmNs7n0C5KzxyTg4D9quryruUmVXVxj2H2wnrL/BZT3d9kb4GSbA48ENi6qt6WZBtgnao6uefQetV9CLatqp/1Hcsk8SQ7t+5kuwRYajJzlcXmR7+gw5QvNi9p4UbPQ1X12STXAaiqC/uNTJPIesvyFlvd3zF7C9AtNvknWtPtTLeHGwEf6C2oniXZPsmPaV3Qvt2VPTrJh/uNbPJU1Q+BDWZOtNOqm5Dlv4FXV9UVSW6S5FZ9x9WznbrbziO3md8labV0XeOPAfYD9u+K9wCmdpbfNM9O8p0k/9eV7Z7ksX3HNmmstyzOur/J3sK8G3hcVd2fth4LwM9p09JOqw/RpiveiGUTsXwLuE9vEU0IT7LLS/IY4HBa15A9u+KNgHf2FtQEqKoT5rv1HZukRe0DwGuqaheWnaN/QFsaaVq9Dngm7dy8fVd2MvCK3iKaENZb5vRuFlnd326cC5Dk7KratLt/VlVt1nVHW1pVm/ccXi+SnAks6Vpozqqqzbryc6pqk36j61eSHwEfqqoDZ9473dWxY6pq277j60OSo2lrPh05ckzWB/5WVUv6jm+ckuxbVc/p7h/I3Iv8UlV7zlUuSVenWx5ps6qqWefoK+9PmyQnAbftxonPnIcCnDVTx5tW1luWtxjr/rbsLcwfktxvVtm9gd/1EcyEOB244WhBkpsBEz14dUxuTpumGLqKfDdGYlqndAbYEvi/7n6N/JzGq1DHjdz/C222s7lukrS6jgduP1rQrWf6l16imQzrAhd092fOPRuOlE0z6y3LW3R1f5deWJiXAYcl+QpwrSQfoq0x97B+w+rVO2jH5M3AekmeAPwX8JZ+w5oIx9NOslfOLOlJll8BT6FNfT3j8cAv+gmnVz9PMrOO3uG9RiJpqF4NfCXJB2ljr15Jm0r/2f2G1auvAe9M8hJoY/ho66Yd2mtUk+F4rLfMtujq/nbjXICu2fZ6wJOBHWjrs3xiUmfjGZckDwOeSzsmJ9K6AHyx16AmQJIH0/q8f5D2ZfFGupNsVX2zz9j60k3O8k1aq9adgO8DNwbuW1V/7jG0sUty3NXvRVWVk7RIWm1JbktL7mbqLftV1a/6jao/STYGPkabXXF94B+089KeVXV+j6H1znrL8hZj3d9kbzUlmWn236SqLuk7nknQHZPvAPfzmMzNk+wy3dXTnYAzgPuz7JgcVlV2n5GkNag7Rx8D3MxzdNMdk5lFsjemOw9V1Wm9BjZBrLcss1jr/iZ7C5DkSOABVfW3vmOZFElOAHaZxsVHV8ST7NySXEhbNH3q19aTpLUtyTHAHarq3L5jmRROIDc36y1zW4x1f8fsLcwnaf1230ObpvfKzLmqvttbVP3aG/hAktey/DGZ2gp9VV2e5HLgmoBfmsv8htZt8499ByJJU+DdwEFJ3sTy5+i/9hVUzw5N8pCqcozeCOst81p0dX9b9hZgBWNspnZcTZKZhG70jRXaMVm3h5AmRpIX0AbwepLtJHkDrd/7x2jdQ0aPyTSv4yNJa9zIOXq2qT1HJzkYeCjwU5Y/D031UjfWW5a3GOv+Jntao5LsMN+2aV8Q2pPs8pJ8b55NVVX3nGebJElrRNcTaU5Vtfc4Y5k01luGwWRvAZJ8qaqWm2o1ySFV9cg+YpIkSZpLkvdW1YvmKH93Vb24h5CkRSfJesBdgG1pLZ4/rap/9hvV/Ez2FiDJeVW18RzlZ1XVZn3E1LckBzL3gtiX0D4QX6yqI8cblSZVkiXAxVV1QTcYfE/gcto0xlM7xlOS1oYV1FvOrKrN+4hpEnRrnD4B2Ab4G/CZqvpOv1FNniQ7A1dU1fF9x9KXbsmoQ2kLy58EbEdbruMhVXV0n7HNxwlaVkOS13V3Nxi5P2NnYJq7K55LWyT7yyz7EDwE+AxwU+AVSZ5XVR+f/ymGKcnhrDgRPmQKB4gfRluz5ze0MQEPBi4Dbgu8pMe4JGkwkjyju7veyP0ZO9OWwJlKSV4GvAL4KO1ctD3wqSRvq6r/6TW4niX5NPC/VfWTJE8H3g9ckeRFVbV/z+H15f3AvsA7qmsxS/IfXfk9+gxsPrbsrYYkH+3uPok2K8+MAk4H9q+qv4w9sAmQ5JvA3lX145GyOwOvq6r7JLk/8O6q2qW3IHuS5PW09XwOYFkivCdtfZ8AzwTeXlVv6y3IMUtyNrBZVVWSk2ndIi4AjqqqrfuNTpKGYWR89N2Aw0c2zdRb3lNVPxt7YBMgySm09YF/P1J2c+BbVbVNf5H1L8nfgetX1aVJfke7OHsOrZfWjXoNridJzgKWVNXlI2XrAUuratP+IpufLXuroaqeDpDkJ1W1X9/xTJg7Aj+fVXYEsFt3/xvA9cca0eS4L+2EcmUzf5JPAgdU1R2THAJ8GpiaZI/WZXODJDcGzq2qE5OsA2zYc1ySNBhVdQ9oMyBX1av6jmcCzb5A/1fm7okzbTboEr1taRdmfwyQZKue4+rT34A9gNFlFu7WlU8kk72F+XGSrarq9CQbAv8JXEFrnbmo59j68lvgjUleW1X/SHJNYC9gZpzeTsBZPcXWt11oJ5BRJwA3AaiqX0zhF+jXgIOAzWldfQFuBpzSW0SSNFzvSbLhtI+T7i4qztgL2D/JXrQhFdsBrwbmnaVzivw2ySuBHYCvAHSJ33m9RtWv/wK+nOQwWh1uB+BBtGWkJpLdOBcgyZHAY6vqT0k+SKu0/wM4o6qe0m90/UiyI61b4q60pG4zWsvek6rquCS7AterqsP6i7IfSQ4FzgdeQzuhXJ92ktmkqh6c5Ja0cXtT0zUiyTVoXVsvAw6sqn8muTvtPfKZFT1WkrRqkvwceF5V/SbJW1k2Tvp7VTU146S7JQVmKsAZ2TRaNvXLCyS5AfB62nvkP6vq70keDdyhql7Rb3T96XojPZZlE/ocVFXH9BvV/Ez2FiDJuVV13SSh9Xm/GXAxcFxVbdlvdP1Ksh3tQ3BqVZ3YdzyTIMlmtAG8jwTWBf4JHAL8W1WdkeQmwEZVdUSPYfaiu8q6VVWd2ncskjRUjpNuVrQm8KhpXh+4a/l9LfCmqvpH3/Fo9ZnsLUCS04Eb0pK891XVrt0gzbPmmtp4miTZklnjrqpqdhfGqdQlNktog3mnptvMXJJsQkuAHw1cVlXXSfJQYDfHlUjSmpXkDNraYDemLS9w8+6cdG5VbdRvdJo03ftlS+sq8y4rdhVVtecYwllljtlbmE/RBmhuBOzTld0OOK63iHrWzba5PzD7CmHRWrOmWpLr0rr7btj9DkBVfXcFDxuyDwJn0/q8/6Er+ynwP4DJniStWY6TnsX1gVfo47QZON/fdyA9W9Qz7Nuyt0BJ7ktrkfhe9/uuwMbTWnlPcizwdtoMkxf3Hc8kSfI04H20LjOjE/hUVe3cS1A9S7IU2KaqLktyVlVt1pWfW1XX7Tk8SRoUx0kvL8k+zL8+8CbAQ2njHKdxfeAf0WZZP4V2bK5MGqpq977i6luS+wBPoLV6PnjS6/4me2tAku1p3SJOmfbxad36I5uXb6zldGv5PKuqvtZ3LJMiyV+Au1XVqTPJXvd5+uY0rsUoSeMwM04aON0ueq4PPJ8kT51vW1UdMM5YJkWSfwP+Hfgw8Mpu7o6bA/tV1V36jW5uJnsLkGRr2pWfO9Fmntyc1gXtCVU1settrE1J3g4cXVUf6TuWSdON8dxmdCHOaZfk/9Gumv438AXgAcCbgC9V1bt7DE2SBifJxsD/Ao8H1qe18H0GeFFVndtnbH1Jci7tIvU/R8rWp82sPjMJ3/lV5fqvmunBdq+qOj7J2VW1aTeZzd+ravO+45vLOle/i1bgA7T14zbrZrHalLbO3Af7DKpndwI+kOSYJD8cvfUd2AR4K/CqWev7TLu3Ap+ldW9dH/gI8CXgPX0GJUkD9V7amPFbAtfqfl67K59Wv6WtD3xNgO7n63F9YACSPD3Jd5P8qfv59L5j6tlGtC6tsKxb6/rApf2Ec/Vs2VuAbpairavqspGya9C6c27RX2T9scl/fklOAq5H+0I4c3RbVW3fS1CSpKmR5DRg56q6aKRsQ+DYqtqqv8j6060P/Gng9rg+8FUk+W9gT9qkaTMLiL8E+ERVvbHP2PqS5HPAb6rqjSPDT14O3Kaqnth3fHNxNs6FOZs2i9XoLE03Ac7pJZoJMO0J3dV4ct8BTKJuoPPjaQOdHzLpA50laRH7B23pn9H147agzTw5rbavqjt348W3plsfOMkTaOsmT93atyOeBdx9dL3BJN8AfghMZbIH/BtwaJJnAxsl+RNwPvDgfsOan8newrwN+HaS/Vl2xePpwKt7jWrMkjylqg7s7j9jvv2mfRxfVf2g7xgmzayBzo/uii+mdSmayIHOkrSIfRj4VpJ3ctWWmn17japfn0vyUeBVXZK3SZLPAreltfhNs+sAS2eVnUnrAjyVugnl7gDcgfb5OQn4xSRPdGQ3zgVKck/gicA2wN+AT1fVd/qNarySfLWqHtjd/948u1VV3XOMYU2EJP8909Uhyevm26+qXjO+qCbHYhzoLEmLVTfZyNOZVW8BPjKts2gn2Qb4KG120v8F9gK+Cry0qi7sMbTeJfk4bYza/wNOpCU3bwQuqqqn9BmbVp7JnrQWJflAVT2/u//R+farqqkc8Jzk77Rxr5eP9H2/Jq3rzNZ9xydJGr4k1wJ+Dtwc2L+qntNzSBOhm711H+BxLJu99bO02VvP6TE0rQKTvQXopuZ9FW0xzpkrZAcCb6yqiZ2VZ21K8puquu0c5UdU1a59xKTJtRgHOkvSYtbNpvgUuvWBaYurz3sxcuiS3Ab4BPAXWjfXdwO/AF5gQtN0s4hvQVuOYmK7K2puJnsLkORdwG7A3izr+/5q4IiqekmfsfUlyflVtdGssgBnVtVmPYU1EWaSmTnK/15VW/YRU9+6tSoPpZ1EtgX+SjfQuapO6zM2SRoaZ1dcXpIzgZdX1f7d79ehjRu/b1Vt12twEyDJjYDHsqxR46Cq+nO/UWlVmOwtQJKTgVtX1ZkjZVsAR1bVtv1FNn5dv25oTf2fnbV5R9p77W5jDWrCzJMIrw+cNo3j07orhXcHfkpb62lRDHSWpMUqyXEsP7viDsAPq2qH/iLrT5Kdq+qvc5Q/tKq+3EdMkyLJE2mT93yFdnFge+BBwHOr6lN9xqaV52ycC5NVLB+yY+e5X8CPgYPHG87kSHI47Thcc47F5a8P/GT8UfWvqq5I8qUuAf5Fd5MkrT3OrjjLXIleVz7ViV7nDcADq+rKukuSu9GGLJnsLRImewtzMG2tjb1ZNkvRq4CDeo2qB1W1N0CSn1XVN/qOZ8J8mHYB4A7A/iPlBZwOTPN6cj9Mcqeq+lnfgUjSFPg68Mkks2dX9LytuWxE630z6me0iwZaJOzGuQBJNqAld7OnMH5DVU3lAqVJ7gEcX1XHJbke8FbgCuCV0z4GK8kuVfXHvuOYJEneDzwB+BKtC+eVX0jTuhyFJK0tzq6oVZHklcBmwKur6h/drKV7A2dX1Zv7jU4ry2RPa1SSo4H7dQuTzjTxXwwsqaqH9hha75I8AfhtVR2d5Ca0fvBXAM+f1iTQ5SgkafycXVHzSTJ64TXA9brfzwY27cpOrart+4lQq8pkb4G6RdWfwLKWvc9M26Lqo5KcV1UbJ1mP1kVxB+BS4G9VtUW/0fWrW0D8LlV1epJDgT8BFwC7T+OC85Kk8XN2Ra1Ikj1WZr+q+sHajkVrhsneAiR5GfAK4KMsm6Xo6cDbqup/+oytL90MpbcHbgHsVVV367q7Lq2q6/YbXb9GEuFrAqfSrpZdRruyOpXLUrgchSSNj7MrStPHCVoW5qXAPavq9zMFSQ4EvkVbw2Ya/S/wS2AD4MVd2V2BqeymOMvSJDekLTPwy6q6JMm1mc7ZW2esP7ugW45i3R5ikaShc3ZFrbTuYv3TgNsAG45uq6o9ewhJq8Fkb+H+Muv3vzIyycS0qaq3JvkCcHlVzSzBcArwrB7DmhSvB34FXE4bHA9wb+DI3iLqictRSFIvnF1Rq+IA4NbAobShOVqE7Ma5irpBzTOeSVsUei/gZGA74NXAD6rqw2MPbkJ04/XuAmxLS/R+UlX/7DeqydC15FFVF3W/bwmsM20zlSZ5Kq1F8wPA80Y2XbkcRVVd1kdskjRUzq6oVZHkbGAnZ2pd3Ez2VlGSK7jqLEUzRsuqqqayG1qSXWhXgK5Fm0p/O+AfwEOq6ug+Y5sESTYFHsKyRPiwqjqr36j643IUkrR2ObuiVleSI4H7VpWteouYyd4qSrLDyuxXVSes7VgmUZLvAl8D3lHdmyvJfwAPqqp79Bpcz5LcmTYo/o8sGxh/U9qxmd2tZmok2QrYjTYN+JUXUKrqI70FJUkD4eyKWhXdLPMzbgs8BngPs7pxVtV3xxmXVp/J3gIk+Y+qescc5S+tqnf2EVPfkpxFW1Pv8pGy9WizcW7aX2T9S/Jz4F1V9ZmRsscB/1FVd+gvsv4keTjwCeDPwM2Bo2gzuf5o2i8OSJI0bkmOW4ndqqp2XuvBaI0w2VuAman05yifczr5aZDk98CLRq/4JLkHsE9V3by/yPrX9X3ffHQB2yTr0pZemMpEuHu/7F1VByc5u6o2TfJ04OZV9R99xydJQ5PkNsDdWL43xWv6iknS2uNsnKthpIl73S6RGR27tzNw/vijmhj/BXw5yWG0roo70NbweXKvUU2GPwOP56rTWz8GOHbu3afC9lV18KyyA4DTAJM9SVqDkjwHeBfwTeABtGEX9wW+1GdcktYeW/ZWw0gT9/bAiSObilZJfUtVfXnsgU2IJDcGHgtsA/wNOKiqjuk3qv4luQtwGHAMLRHeEbgR8OCqmsqlBpL8BbhrVZ2e5DfAC4AzgJ9V1eb9RidJw9J95z69qg4f6U3xAODxVfXUvuPTZJk1uc+oS2iz0B8CfMAZ1yebyd4CJPm4i0rOrVuiYivg9NFui9Oum43zQSxLhL865bNxvgL4S1V9PsmewL7AFcD/VNWr+41OkoZldPhJkjNpY+yvmObhJ5pfkv+k9cx6L22G9e2BfwUOBs4CXgZ8oape3luQulome1qjkmwM7ENbNHw94J/AZ2jj+M7tM7ZJkWR7uqUXqurEq9t/yJKsM2sM4/bAdVymQ5LWvCR/AB5YVccn+SnwNlpvioOr6nr9RqdJk+Qo4D5V9beRsm2Bb1bVzZPcBPh2VW3XW5C6Wutc/S6aT5KNk7wzya+SnJDkxJlb37H16L3AdYBbAtce+fnePoOaBEm2TvID2ti9Q4C/JPlhkm16Dq0X3eQ0Fya5xkxZVZ1ooidJa83baEv+ALyONhvyd2kLq0uzbQ1cMKvsQlrvJGjDUjYZZ0BadbbsLUCSTwDXpw12/gStqfs/gc9X1bv6jK0vSU4Ddq6qi0bKNgSOraqt+ousf0m+SBvj+cqqujDJdYA3ATtV1UN7Da4n3YKtDxi9aihJGo8kGwAbVNXsCr1EkgNoXTffSBujd33glbSeSXt2cxF8qKpu2WOYuhomewuQ5O/ATavqzCTnVNUmXfP2oVV1u77j60OS44E9RheVT7Ij8MOq2r6vuCZBkjOAravqspGya9C+NLfoL7L+JHk5bYbS99BOJFd+IblgqyQtXDeG/mo5vl6zJbkmsBdt5vBtgFOBg4DXVdVFSa5Hu1gwzT3aJp7J3gJ0lffrVdU/k5xMWxT6fOCcudbfmwZJXgXsCbyTZUsvvAQ4sKre0GdsfUvyZ+DRVXXkSNmtgEOq6ob9RdafFSze6oKtkrQGJLmCuWdUvIqqWncM4UgaM9fZW5gjgT2A7wCHA++n9W2e5mUG3kibZfKJLJtx8m3AR/oMakK8Dfh2kv1Zlgg/HZjaWSeraqe+Y5CkgRv9nn0Q8GjgzSw7D70C+HwPcWkCJdm9qn7Y3b/nfPvZ+2bxsGVvAZLsDFBVf02yJW381YbA3k4yobl0X5yjifCnq+o7/UbVnyRfqqqHzVF+SFU9so+YJGmounX2dq2qc0bKNgWOqKob9BaYJkaS31fVLbr79r4ZAJO9BUjyXuAzowtid4NVH1tVL+4tsJ4leQbwBJYlNJ8BPlK+2TTL6JpPs8pd80mS1rAkS4FbzzGV/pHTOnZcGjqTvQXovjS3rapLR8quAZxUVVv2F1l/krwNeBjwbpZ1EXkRbdKaqV50s5v17FUsnwi/sar+0Wds45bkdd3dl9O6t47aGbh5Vd12vFFJ0rAleQfwQNo5+iRgO9o5+ptV9dIeQ9OESrI+cCdgm6r6bDeTOFV1Yb+RaWU5Zm9hiuXXKlx3jrJp8jTgdlV18kxBksOAX9Mq9tPsA8BNaCfWmUT4v2gLrD+jx7j6MLMA6zoj96F9pk6izf4lSVqzXg78BXgcyy467gPs22dQmkxJbgl8GbiEtuzCZ2lzVTyV9h7SImDL3gIk+TxwHPDyqrqim974LcCNquoR/UbXjyTH0pK9c0fKNgF+Ne3jAZKcCdxg1liJzYC/TGuXxSTPrqr9+o5DkqZFkq2AOwJX6bZZVU6kpqtI8iPaOnoHJjm7qjbtWvaOqapt+45PK8eWvYX5d+Aw4NQkJ9AWnjwVeEivUY3ZzEQ1nXcDhyR5C23dtO1oC81P5SLzs5wGXBs4Z6TsWrT3zLS6eHZBkgD/r6re3EM8kjRYSR4OHEhr3bs5cBRwC+BHOGu2lndz4BPd/YLWfTPJtfoLSavKlr0F6lrzdqMlNScBv5i2hUlH1vDJCnaraVzDZ9a0xbvRZuL8X5Ylwv8KfKqq3tpDeL3r1h78NfC8qjq7u3BwIHBFVd2t3+gkaViS/J42Y/jBIy01T6eNk/6PvuPTZEnyG+DZVXXEzMRpSXYD9qmq3fqOTyvHZE9ai1YwbfGoqZ3CuOsO8m7g/sDHgBcA7wDeOm0XTSRpbRudAXkk2VsHOG1aJ5bT/JI8GNgf+CDwMtpays+jJYDf7DM2rTyTPa1RSd5bVS+ao/zd07wcheaXZAnwHVpXogOAZ7hMhySted06e3etqtO7VpsXAGcAP6uqzfuNTpMoyW2BZ9MmlTsJ2K+qftVvVFoV0zxrpNaOp81T/pRxBjGJknxpnvJDxh3LpEjyIOBI4HvArWizlR6eZKdeA5OkYdoP+Jfu/rto371HAu/vLSJNtKr6TVW9oKoeVFXPM9FbfGzZ0xrRLaQObQrnF87avDPwmKq6yXijmiwuIL68JCcBT6+qb3e/rwP8N/BirzJL0tqVZHvgOlV1dN+xaPJ06wM/DbgNsOHotqras4eQtBqcjVNrykzL3QZctRWvgNNpa7JMpZEFxDcYuT9jZ9qae9PqVsCuSfYHtqyqhyT5Gm1NH0nSWlRVJ/YdgybaAcCtgUNpdTktQiZ7WiOq6h4ASd5QVa/qO54J4wLi83sS8GLgw8Cju7KLgYcDb+snJEmSRJs8bafR9YG1+NiNU2tFki1Zvsn/rz2FMxFcQHx5SY4F7lVVx4/MDLcu8He7cUqS1J8kRwL3rSpb9RYxW/a0RiW5H21h1q1nbSpg6tbZG1VV+yW5Lm0SktmJ8Hf7iap3G9FaN6FbsBVYH7i0n3AkSVLn48CXkryHWd04p7jesujYsqc1qmupeTtwQFVd3Hc8kyTJ04D3ARcAF41smuZ19j4H/Kaq3jiyYOvLgdtU1RP7jk+SpGm1grWCp7beshiZ7GmNSnIWsLnrpC0vySnAs6rqa33HMimSbE0b+L0FsC3wV+B84MFVdVqfsUmSNM2SPL6qPjNH+euq6jV9xKRVZ7KnNSrJ24Gjq+ojfccyaZKcDmxTVZf3HcskSRLgDixbsPUXVXVFv1FJkjTdkvwV+NfRi9RJ3gQ8oKpu219kWhUme1qjkhwO7EZbTuAqLTNVtXsvQU2IJC+ljVF7vcmMJEmaZEluCnwdeHJVHZ7kncDuwH2q6ux+o9PKMtnTGpVk3vX0quqAccYyaboFxK9Hm3zkzNFtVbV9L0FJkiTNI8ntgC8BPwa2B+5fVef1G5VWhcmeNCZJ9phvW1X9YJyxSJIkzZbknnMU7w48F3gebVy9s3EuIiZ7WqO68VfPAp4AbFFVt0qyO3C9qjqo3+gkSZI0nxXMwDnK2TgXEZM9rVFJXg/cB3g38MGq2iTJzsDBVXX7XoPrWZJrAK+hJcKbV9V1k9wXuHFV7dNvdJIkSRoakz2tUd24tNtW1RlJzq6qTbvWvrOqatO+4+tTkvfTlhd4C/C1LhHeFvhmVd283+gkSZI0NOv1HYAGZ13aouEAM1cSNhwpm2aPAG5YVRcmuQKgqk7pEj5JkiRpjVqn7wA0OF8F3tl1WZwZw/d62sLZ0+5SZl1gSbKEWTNzSpIkSWuCyZ7WtJcCWwPnAteltejtALyiz6AmxMHAAUl2AkiyNbAP8Jleo5IkSdIgOWZPa0WSrWjrsZxUVadd3f7TIMkGwFuBZwPXBi4C9gNeUVWX9hmbJEmShsdkTwuWJNW9kZLM21pcVVeML6rJ1nXfPKP8AEqSJGktMdnTgiU5r6o27u5fwbKJWa7chbYmy7pjD65nSXasquO7+/OuSVNVfx1bUJIkSZoKzsapNWF02YCdeotiMv0O2Ki7/xdaIpxZ+xRtFlNJkiRpjbFlT5IkSZIGyJY9LViSA1m+6+ZyqmrPMYQjSZIkCZM9rRl/Gbm/BfBU2rp6J9Bm5HwIcEAPcfUuyeGsXCK8+xjCkSRJ0hQx2dOCVdXeM/eTfAN4UFUdPlL2L8Cr+4htAnx45P4NgGfQEt+ZRPipwEd6iEuSJEkD55g9rVFJzgW2qKrLRsrWB86cmbFzWiX5GfDMqjpqpOxmwEeq6k79RSZJkqQhmndNNGk1/QZ4U5JrAXQ/3wj8ts+gJsRNgWNnlR0H7NJDLJIkSRo4kz2taU8D7gqcm+R04FzgXwAnZ4EfAB9LcqMk10pyY2B/4PCreZwkSZK0yuzGqbUiyfbA1sCpVXVi3/FMgiSbAe8HHklbV++fwCHAv1XVGX3GJkmSpOEx2dNakySMLCBeVVf0GM7ESLIOsARY6jGRJEnS2mI3Tq1RSbZJ8oUkZ9Jari4buam5DnBtYMckOyfZue+AJEmSNDwme1rTPgRcCtwLuAC4HfBl4Hl9BjUJktwsyW9o4xj/0t3+3N0kSZKkNcpunFqjuha97avqwiTnVNUm3Vi1n1TVVM86meT7wK+B19Fm4dwReDPt2Hyiv8gkSZI0RCZ7WqOS/B3YrqouSXI8cAfgPOCMqtqo1+B6luRsYMuqumwkEb4O8Puq2qnv+CRJkjQsduPUmvZz4IHd/W8An6XNOHlEbxFNjn8A63f3z+hmLF0H2Ly/kCRJkjRUJnta055CW08O4MXAd4HfA0/sK6AJcjjw2O7+54Cv0Y7Vd3uLSJIkSYNlN06tMUnWBT4CPKeqLuk7nknWLb/wRGAj4ONVdWHPIUmSJGlgTPa0RiU5lTZBi0stjOgS4e8A9zMRliRJ0jjYjVNr2ruAvZOsf7V7TpGquhzYCT9zkiRJGhNb9rRGJTkJuB5wObAUKCBAVdX2fcbWtyTPAHYHXgucTDs2AFTVFX3FJUmSpGEy2dMalWSP+bZV1Q/m2zYNkswkdKMfuplEeN0eQpIkSdKArdd3ABqce81TfkmSHYGvV9XpY4xnkriWniRJksbGlj2tUUk+AzwC+AVwErAdsBtwKHB94JbAo6rq670FKUmSJE0BW/a0pq0DPL6qvjBTkORhwBOr6k5Jngq8BZi6ZC/JgVy1C+eMS2hj+L5YVUeONypJkiQNlTMDak27H/DlWWWHAQ/o7n8C2HmsEU2Oc4GH0cbpndz9fChtMpubAj9Nsmd/4UmSJGlIbNnTmnYs8Hxgn5Gy53XlAFsAF407qAlxY+CBVfXjmYIkdwZeV1X3SXJ/4N3Ax3uKT5IkSQPimD2tUUluBxwCrAucAmxLa7l6ZFX9OsnuwE2qar8ew+xFknOBzavqnyNl6wNnVNV1kwQ4v6o27C1ISZIkDYbJnta4LoG5E7ANcCrw06q6rN+o+pfkB8DPgNdW1T+SXBPYC7hLVe2eZGfg+9O+HqEkSZLWDJM9aUyS7AR8EtgVOAvYDDgCeHJV/TXJrsD1quqwHsOUJEnSQJjsSWOWZDu6Vs+qOrHveCRJkjRMJnvSmCT5TVXddo7yI6pq1z5ikiRJ0nC59II0PjecXdBNyjKtS1FIkiRpLXLpBWktSzKzlMIGI/dn7AgcNd6IJEmSNA1M9qS179h57hfwY+Dg8YYjSZKkaeCYPWlMktyvqr7RdxySJEmaDo7Zk8bn0m75BZJcL8kBST6a5Hp9ByZJkqThMdmTxuf9wOXd/XcC6wNXAPv2FpEkSZIGy26c0pgkOa+qNk6yHnA6sANwKfC3qtqi3+gkSZI0NE7QIo3PeUm2Am4B/KGqLkiyAa2FT5IkSVqjTPak8flf4JfABsCLu7K7An/sKyBJkiQNl904pTFKcmPg8qo6duT3a1TV7/qNTJIkSUNjsidJkiRJA2Q3TmktSnJ0Vd20u38SbSH15VTV9mMNTJIkSYNnsietXc8euf/k3qKQJEnS1LEbpzQm3cybTwNuA2w4uq2q9uwhJEmSJA2YLXvS+BwA3Bo4lLbOniRJkrTW2LInjUmSs4GdquqcvmORJEnS8K3TdwDSFDkRuEbfQUiSJGk62LInrUVJ7jny622BxwDvYVY3zqr67jjjkiRJ0vCZ7ElrUZLjVmK3qqqd13owkiRJmiome5IkSZI0QI7ZkyRJkqQBMtmTJEmSpAEy2ZMkSZKkATLZkyRJkqQBMtmTJEmSpAH6/3nJ2dYKLBRLAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "graph_cv_model_performance(results_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "duplicate-speaking",
+   "metadata": {},
+   "source": [
+    "### Two estimators have higher accuracy than ExtraTreesRegressor, Seven higher than EloRegressor\n",
+    "\n",
+    "Ridge and CatboostRegessor all got a higher accuracy than ExtraTreesRegressor, which is currently one of the base estimators in the ensemble. In addition to these, LinearSVR, GradientBoostingRegressor, SVR (with 'rbf' kernel), and HistGradientBoostingRegressor got higher accuracy than EloRegressor. To make sure that adding additional base estimators will actually improve overall performance, we'll measure accuracy after adding each one, starting with the best performing: Ridge."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "knowing-browser",
+   "metadata": {},
+   "source": [
+    "## Add new estimators to stacking ensemble"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "constitutional-record",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T20:38:13.883636Z",
+     "start_time": "2021-02-15T20:38:13.758464Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(1, 'ridge'),\n",
+       " (2, 'catboostregressor'),\n",
+       " (3, 'linearsvr'),\n",
+       " (4, 'gradientboostingregressor'),\n",
+       " (5, 'svr'),\n",
+       " (6, 'extratreesregressor'),\n",
+       " (7, 'histgradientboostingregressor'),\n",
+       " (8, 'eloregressor')]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "top_estimators = [\n",
+    "    Ridge(),\n",
+    "    CatBoostRegressor(random_seed=SEED),\n",
+    "    LinearSVR(),\n",
+    "    GradientBoostingRegressor(random_state=SEED),\n",
+    "    SVR(kernel='rbf'),  \n",
+    "    ExtraTreesRegressor(random_state=SEED),\n",
+    "    HistGradientBoostingRegressor(random_state=SEED),\n",
+    "]\n",
+    "top_ensembles = []\n",
+    "regressors = []\n",
+    "\n",
+    "for estimator in top_estimators:\n",
+    "    regressors.append(\n",
+    "        make_pipeline(\n",
+    "            DataFrameConverter(), BASE_ML_PIPELINE, estimator\n",
+    "        )\n",
+    "    )\n",
+    "    pipeline = StackingRegressor(\n",
+    "        regressors=[*regressors], meta_regressor=META_PIPELINE\n",
+    "    )\n",
+    "    top_ensembles.append(StackingEstimator(pipeline=pipeline))\n",
+    "\n",
+    "# Append Elo estimator separately, because it requires a different pipeline from the others\n",
+    "regressors.append(ELO_PIPELINE)\n",
+    "pipeline = StackingRegressor(\n",
+    "    regressors=[*regressors], meta_regressor=META_PIPELINE\n",
+    ")\n",
+    "top_ensembles.append(StackingEstimator(pipeline=pipeline))\n",
+    "\n",
+    "[(len(ensemble.pipeline.regressors), ensemble.pipeline.regressors[-1].steps[-1][0]) for ensemble in top_ensembles]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "statutory-billy",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T03:50:37.565723Z",
+     "start_time": "2021-02-15T02:58:33.678973Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:   25.0s finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  1.7min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  1.9min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  3.7min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed:  9.6min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "/usr/local/lib/python3.8/site-packages/joblib/externals/loky/process_executor.py:688: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+      "  warnings.warn(\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 11.1min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 11.5min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 12.0min finished\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'fit_time': array([6.47730875, 6.61284995, 6.67107677, 6.79929113, 6.09728408]),\n",
+       "  'score_time': array([0.2807951 , 0.27366233, 0.23755908, 0.27848339, 0.23464632]),\n",
+       "  'test_neg_mean_absolute_error': array([-36.30861274, -35.02158139, -34.58206789, -30.79320129,\n",
+       "         -35.3605057 ]),\n",
+       "  'test_match_accuracy': array([0.68932039, 0.72463768, 0.65217391, 0.72463768, 0.60869565])},\n",
+       " {'fit_time': array([71.54306149, 72.83449888, 73.52198648, 73.39540625, 30.64464617]),\n",
+       "  'score_time': array([0.33718157, 0.3210144 , 0.2883606 , 0.26059389, 0.2810452 ]),\n",
+       "  'test_neg_mean_absolute_error': array([-35.34884427, -32.78830328, -32.64849455, -32.70377626,\n",
+       "         -32.65424531]),\n",
+       "  'test_match_accuracy': array([0.68446602, 0.70048309, 0.65217391, 0.67149758, 0.59903382])},\n",
+       " {'fit_time': array([78.35910606, 77.62702012, 79.57254457, 79.74348307, 35.81066561]),\n",
+       "  'score_time': array([0.36737037, 0.36650252, 0.31390285, 0.30758786, 0.30325079]),\n",
+       "  'test_neg_mean_absolute_error': array([-34.3303511 , -32.15572688, -33.14772217, -31.68573756,\n",
+       "         -31.96730704]),\n",
+       "  'test_match_accuracy': array([0.66990291, 0.72463768, 0.63285024, 0.70048309, 0.61352657])},\n",
+       " {'fit_time': array([133.68500996, 136.62713981, 140.80792856, 142.03661752,\n",
+       "          84.5416894 ]),\n",
+       "  'score_time': array([0.47684407, 0.42646432, 0.31394362, 0.32575798, 0.33331466]),\n",
+       "  'test_neg_mean_absolute_error': array([-34.34523877, -32.17523312, -32.40043956, -31.11882092,\n",
+       "         -31.06115886]),\n",
+       "  'test_match_accuracy': array([0.71359223, 0.73429952, 0.66666667, 0.72463768, 0.5942029 ])},\n",
+       " {'fit_time': array([333.24091768, 351.20111847, 367.97069597, 369.82646966,\n",
+       "         235.18042088]),\n",
+       "  'score_time': array([5.42375875, 8.26364923, 5.15370154, 5.48007178, 4.05410218]),\n",
+       "  'test_neg_mean_absolute_error': array([-34.1837675 , -31.5289504 , -32.51452084, -31.00244355,\n",
+       "         -30.49136333]),\n",
+       "  'test_match_accuracy': array([0.69902913, 0.73913043, 0.65217391, 0.71980676, 0.62318841])},\n",
+       " {'fit_time': array([342.13699555, 370.72494388, 373.6541481 , 390.46895528,\n",
+       "         305.67520356]),\n",
+       "  'score_time': array([5.27996802, 6.47295403, 5.74513793, 4.40533853, 4.52119946]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.9417758 , -29.19268902, -28.34437142, -26.43500028,\n",
+       "         -27.83877514]),\n",
+       "  'test_match_accuracy': array([0.70873786, 0.7294686 , 0.67149758, 0.74396135, 0.65217391])},\n",
+       " {'fit_time': array([349.22148561, 377.13349915, 393.60506701, 399.95083928,\n",
+       "         331.06335139]),\n",
+       "  'score_time': array([5.43781543, 6.41560936, 4.91124296, 4.55285549, 5.03804588]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.94538129, -29.19336311, -28.34893551, -26.4388271 ,\n",
+       "         -27.83734974]),\n",
+       "  'test_match_accuracy': array([0.70873786, 0.7294686 , 0.67149758, 0.74396135, 0.65217391])},\n",
+       " {'fit_time': array([412.621943  , 426.69702315, 447.91414452, 455.73418212,\n",
+       "         296.9209671 ]),\n",
+       "  'score_time': array([6.0632062 , 5.84506726, 5.14232826, 5.07547736, 4.57344508]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.94443582, -29.19261881, -28.34913914, -26.43912201,\n",
+       "         -27.83678098]),\n",
+       "  'test_match_accuracy': array([0.70873786, 0.7294686 , 0.67149758, 0.74396135, 0.65217391])}]"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ensemble_scores = []\n",
+    "\n",
+    "for ensemble in top_ensembles:\n",
+    "    scores = score_model(ensemble, data, n_jobs=-1)\n",
+    "    ensemble_scores.append(scores)\n",
+    "\n",
+    "ensemble_scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "innovative-reconstruction",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T03:57:31.470012Z",
+     "start_time": "2021-02-15T03:57:31.284022Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>fit_time</th>\n",
+       "      <th>match_accuracy</th>\n",
+       "      <th>mae</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ridge</td>\n",
+       "      <td>6.531562</td>\n",
+       "      <td>0.679893</td>\n",
+       "      <td>34.413194</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>catboostregressor</td>\n",
+       "      <td>64.387920</td>\n",
+       "      <td>0.661531</td>\n",
+       "      <td>33.228733</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>linearsvr</td>\n",
+       "      <td>70.222564</td>\n",
+       "      <td>0.668280</td>\n",
+       "      <td>32.657369</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>gradientboostingregressor</td>\n",
+       "      <td>127.539677</td>\n",
+       "      <td>0.686680</td>\n",
+       "      <td>32.220178</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>svr</td>\n",
+       "      <td>331.483925</td>\n",
+       "      <td>0.686666</td>\n",
+       "      <td>31.944209</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>extratreesregressor</td>\n",
+       "      <td>356.532049</td>\n",
+       "      <td>0.701168</td>\n",
+       "      <td>28.550522</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>histgradientboostingregressor</td>\n",
+       "      <td>370.194848</td>\n",
+       "      <td>0.701168</td>\n",
+       "      <td>28.552771</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>eloregressor</td>\n",
+       "      <td>407.977652</td>\n",
+       "      <td>0.701168</td>\n",
+       "      <td>28.552419</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           model    fit_time  match_accuracy        mae\n",
+       "0                          ridge    6.531562        0.679893  34.413194\n",
+       "1              catboostregressor   64.387920        0.661531  33.228733\n",
+       "2                      linearsvr   70.222564        0.668280  32.657369\n",
+       "3      gradientboostingregressor  127.539677        0.686680  32.220178\n",
+       "4                            svr  331.483925        0.686666  31.944209\n",
+       "5            extratreesregressor  356.532049        0.701168  28.550522\n",
+       "6  histgradientboostingregressor  370.194848        0.701168  28.552771\n",
+       "7                   eloregressor  407.977652        0.701168  28.552419"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = []\n",
+    "\n",
+    "for idx, scores in enumerate(ensemble_scores):\n",
+    "    model_name = top_ensembles[idx].pipeline.regressors[-1].steps[-1][0]\n",
+    "    results.append(\n",
+    "        {\n",
+    "            'model': model_name,\n",
+    "            'fit_time': scores['fit_time'].mean(),\n",
+    "            'match_accuracy': scores['test_match_accuracy'].mean(),\n",
+    "            'mae': abs(scores['test_neg_mean_absolute_error'].mean()),\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "ensemble_results_df = pd.DataFrame(results)\n",
+    "ensemble_results_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "detected-paint",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T03:57:33.171244Z",
+     "start_time": "2021-02-15T03:57:32.327019Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-15 03:57:32,529 - matplotlib.legend - WARNING - No handles with labels found to put in legend.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA44AAAJwCAYAAADGGD9JAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABf2klEQVR4nO3dd5hkZZn38e+PjMAQB0QyIgYMqIiuCCrmiOk1oICua9xdA+u6qyuroJjFsEZUFFBRV0FB1owKmHEVdcBFkByHNDBDhvv945xmiprqmh6YqVM1/f1cV11d/ZynTt2nT3X3uc+TUlVIkiRJkjSdVboOQJIkSZI03kwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkjaEkL01SSR5zJ1//mPb1L12ugWmZJdkuybeSzG/PyRe7jkmLDfpdSbJtW/aOGe7ji0lWyPpmSd7RxrLtiti/JM2UiaMk9em5kKwkH5+mzqZJbmrr/HTEIWqyfBF4NPA+YB/gM51Go7GT5FkzTVIlqSsmjpI0vRuAvZOsOWDbPkCAW0YbkiZJ+9nZHTiyqj5YVV+qql92HZeW6lxgbeBdI3q/ZwFvn2bbu9pYzh1RLJI0kImjJE3vGGBDYK8B214G/A9w40gj0h2ksW7XcQyxGc0NhiuX946TrLe89zmKfU+CatxQVZ3fGKqqW9pYVkhXWEmaKRNHSZre/wJ/pEkSb5dkV2An4AvTvbDtevbzJIuSLGyfD0pASfKKJH9JcmOSM5O8gSbZGFR3/STva+vd2I6bOyrJ9nf2IJPcI8mHkvwhyVVJbkhyWpJ/S7LqgPprJHlzW/+6JAuSnJLkn/rqzUlycJLT231ekeTkJC/sqfPTJOcMeI8lxpj1jkVL8o9JTqNpFX5Tu33XdqzZGW1c17Y/92dPc9x3T/KxJH9rf5aXJflhkie027/d7mfOgNc+rI3lP4f8XL/I4lait/d0f35Mu3219md8Ws/P55gkD5juZ5HkBUl+l+R64L+me++e1z44yX8nubQ9xvPbz8s9e+pU+3N7XHt+FgLH9Wyf0Wc5ySOTfDfJJe3xXJjkf5I8oqfORkk+nOSsnmP+XZJ/XcpxbNDWP3qa7e9pj2Pn9vtl+kwP2N/AMY5J1krygSQXJbk+yW+SPHGafczo85imq/t+7fPqeby0LRs4xrGN8ciec3tWkncnuVtfvanX37vdfkFb/9QkT13az0KSpqzWdQCSNOYOAw5JskVVXdiW/T1wGfCdQS9I8lrgE8BfgIPa4pcC30ryqqo6tKfuG4APA6cCbwXuRpMIXTZgv+sDvwC2buOaB2wOvBb4dZJdqurOdGd7IPAcmhbWs4DVgScD7wW2B17VE8MawPeBxwA/AL5Ek7w9oN3Hx9t6GwAn0yTY3wA+BawKPBh4OvDVOxHnlDcAGwOfBS4Bzm/Lnw3cB/g6TcK2Mc0F+dFJXlxVX+k5jm2Bn9O0CB4BnAKsAzwCeDzww3b/zwRexJLjEl8O3EZzHqbzGeAPNOf3GGAq6Tm9/fpl4Pnte30KuDvwj8Avk+xeVb/v29+zgNe1dT8NXDPkvUnydOCbwCLgc8CZ7Xs8Cbg/zbmesgvw3PaYD+/Zx4w+y0nu3R7HJcBHgUtpfraPAh4E/Kp97X8De7Tx/5GmC+Z9aT5PH5juWKrq6iTHAnsl2aiqbm/BTbIK8GLgj1X1h7Z4xp/pZXQUzXk4jub34J405/XsAXVn+nk8mOZG/u40XeCn/GK6IJJsA/wGWB/4JPBXmp/hW4DdkjxuQGvp4cDNwAeBNWh+j76VZMeqOmepRy5JVeXDhw8fPnoeNBdgRZPAbUzTHfWt7ba1gauBD7bfLwR+2vPaDduyM4E5PeVzaC5grwU2aMs2oLmoPw24W0/dLdt9FPCYnvKPAtcDD+qLdxuaJOKLA47hpTM43rWBDCg/ErgV2Lyn7M3tft89oP4qPc8/2dZ75VLq/RQ4Z0CdbdvXv2PAMV0JbDrgNesMKLsb8H/AaX3l/9Pu60nTxUeT6J4H/GbAPhcA/zODn+0Sx9GWP6Et/1rvz54myboFOGnAPm4G7jvDz/DdgPk0NyC2WMo5qPbx+L46y/JZfl27j12HxLR+W+eTd/L38mnt61/bV/64tnz/O/mZXuJ3ZZrP3xPbsi/27fNZUz/Du/B5/GL/63u2vaPd/7Y9ZV9uy57aV/cDbfnLB7z+O32ftYe15e+5M+fDhw8fs+9hV1VJGqKqrgCOpWllgaYVY32mb2l6Ak3L1ceq6vYWofb5x4B1aVq0oLkQvRvwiaq6rqfuBTQXhrdLEppWlROBC5NsMvWgST5/1e7vzhzj9VVV7fus0XYn3ISmRWUVmtaoKS8GrmJx61Pvfm5r97EK8ELg9OppXe2vdxccUVVLtMhW1aKp50nulmRjmp/vCcB903Y5TbIRTevT96rq+9PFV1W30pznh+WO3UefR5M8ff4uHMNUd8WDp3727XueStOa9agkc/tec3xVnc7MPAnYBPhQLW4pv92Ac3BqVf2or2xZPssL2q97JVlrmpiup7kJ8/D+bpcz9H2alsx9+8r3pUm2b/+dWcbP9Ew9q/16h5bRqvoWTTJIX/mMPo/Lqv39eibw+6r6n77N76FpCR/UPfujfZ+139LcGLjXnYlD0uxj4ihJS/cF4F5JHkXTTfU3VXXaNHW3a7/OG7Btqmz7vq9/GVC3f/9zaVo/n0jTktT/eAJN18Bllmas3duSnEHT7fSKdp9HtlU27Kl+L+AvVXXDkF1u0r7mD3cmnhk4Y1BhmiVSDk1yKU0yfTnNcby6rbJB+3UHmjGk/V1BB/k8TQvVy3vKXk7TknfsMke+2HY0F/iDEsF5PXV6DTzuaUwlAzM5xun2vSyf5a8CP6Lpbn1lkhPa8YTbTL2gqm6i6R55f+DsJPOS/FeSx/XuOMncNONPpx5z29dPJYcPT7JjW3cdmps5P6iqS3v2sSyf6ZnanuacDfpZLXEel+HzuKzm0iTtS5yXarrwXszi89LrbwPKrqD5uyJJS2XiKElL933gQprp8h/L8HFtK8rUZDk/okkSBz2edCf3fQjwTprJgF4GPLXd37+121fk/4rpZoocNgb/uv6CtkX2BzRjyA4HXkDTqvgEYGos2TIfR1WdD3wPeEnbcnUvmjF6R1TVzcu6v7toieMel31X1Y1V9QTg4TStXrfStEr/pXcymKr6NE030FfQfN6eB/woSe+Y19/SJD9Tj9/2bDui/TrV6vgcmiTqcO6oy8/0Cvs83kW3TlM+cCIuSern5DiStBRVdWuSI2gmnrieZoKM6Uzd1d8J+HHftvv11Zn6ep8hdafMpxlbOWdAl8K7ah/gxKp6YW9hkh0G1D0DuE+SNatquqVILqfpzvqgGbz3lcBDB5Qv6yyxD2zf76CqusN6eEn+oa/umTQJ684z3PehNOPrnkUzuQ/ctW6q0Jz7VWgmhvlj37apcz9owpWZmmoV25kmgbkzluWzDEBV/YZm0haSbEXT4vkumklqpupcTDNZz+faGU6PBF6U5ENt98kX04xRnHJ9z2tPTXIqTSJ/AE0CeTVLtv4uy2d6pqbO2Y4s2dp3377vl+XzCNPfQBlkPs340p36NyTZkGbCrD8sw/4kaUZscZSkmfk0cCDw6t7xXgP8kKZb2j+nZy289vk/04wp+mFP3euBf+ydQj/JlsDevTttx6R9Gdg1yfMGvXGSTZf1oFq30tfq0HYBfOOAul+m6eb3tgHvn55YjwLul+Tl09VrnQGsl2aJk6ntq0zz3ks7BljyOO5P33ivtjvfd4GnJHk8ffriAzgeuIhmJs79gJ9X1aDuxcviW+3Xt/S+XxvvM4GTq2r+Xdj/D2gS+H9Jsnn/xgHHOMiMP8vt+MF+F9AkORu1de6WvqUi2nGkU4nzRm3Zz6vqRz2Pn/ft93CaCaH2BvYEvjag6/SyfKZn6tvt1zssHZLkWcC9B7w/A2JY4vPYWthu32hpQbS/X8cBD07y5L7N/05zbXfMEi+UpLvIFkdJmoGqOo9mdsKl1bs6yZtpljD4dZq1/KCZXGcH4FVVtaCte1XbavJB4Bdtq+bdaMZA/ZXFrVtT/gPYDfh6kq/TTIhzE81F9FOB37F4Ep9l8Q3gVUm+RtMVdjOasZxXDKj7UeAZwNuSPIwmQbmBpvXj3iyeLOVtNBf1n0uzzt3JNBfRD6b53zO17MChwL8AxyT5aHs8z2PZ/z+dTtMK9OY2Ofk/mpahVwF/YslWzX+iWe7gu0kOp/nZrU3T1fIcFndpnGpxPozFyfJblzG2JVTVD9tz+EJgwyTfYfFyHDfQzFJ6V/Z/XZu0fwP4c5Kp5Tjm0nRpPoTFidB0+5jxZ5nm8/BEmpk7z6Y518+gaU1/f1tnR+BnSY4B/kzTKn1f4DXta06a4eF9ud3nJ2mSpP5uqrBsn+kZqarvJzkO2K9N8L5HsxzHq9rjuX9P9WX9PP6K5jP5ySTH08yg++uqmq7V+a003V6/leSTNOd2D5ousScy+GciSXeJiaMkLWdV9ckkF9O0TEx1UzsVeHY7A2Nv3Q+lWXB9f5qxYefTJJIL6BtLWVULkuxGk2g9H9iLZjbJC2gSs8/dyZD3p+n6NrXP82kSut/SXHT3xnBTmyD8C02Lz7tpEp2/0kwiNFXvqiR/R3OB+xyaVpZraSb9+a+eeme3LTbvphmTdgVN18XDGDxp0EBtcvc0mp/dfjSzgf65ff4g+i7U2/fdBTiAJunelyaRObU99n6fa49lEc1ahMvDi2nG4L0U+FC7758BB1TVn+7qzqvq2HZCp7fSTOizHs2spCfRJC8z2cdMP8vfouki+XyaJO16ms/EK1jcrfd8mvP6WJpuv2vSjB3+LPC+3pmFlxLTZUm+R7Me6F+r6pcDqs34M72MXkDT9fbFNInbn2g+33vTkzgu6+eRpoX+wTQ3Ev4fTUL8MqbprlxV5yZ5OM040pfQTLRzAc3fkHfVkms4StJdlp6ZmSVJ0gBtd8/zgc9X1Z1dPF6SpInlGEdJkpbuNcCqDG6NlCRppWdXVUmSppHkhcDWNF01v19Vv+s4JEmSOmFXVUmSppGkaMZwngS8rKou7DgkSZI6YeIoSZIkSRrKMY6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNNRqXQcwLjbZZJPadtttuw5DkiRJkjrxu9/97vKqmjtom4lja9ttt+WUU07pOgxJkiRJ6kSSc6fbZldVSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA3lrKqSJEmSNMFuu+02Lr/8cq6++mpuvfXWgXVWXXVVNthgAzbZZBNWWWXZ2w9NHCVJkiRpgl1wwQUkYdttt2X11VcnyR22VxU333wzl156KRdccAFbb731Mr+HXVUlSZIkaYItWrSILbbYgjXWWGOJpBEgCWussQZbbLEFixYtulPvYeIoSZIkSRNuJt1P70wX1dtfe6dfKUmSJEmaFUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkTrqqWS53pmDhKkiRJ0gRbffXVuf7665da7/rrr2f11Ve/U+9h4ihJkiRJE2zTTTflwgsv5LrrrhvYqlhVXHfddVx44YVsuummd+o9VrurQUqSJEmSujNnzhwALrroIm6++eaBdVZffXU222yz2+suq5Emjkk2Aj4PPBG4HHhLVX1lQL3vArv3FK0B/F9VPSDJpsBHgUcD6wB/Bvavql+3r30McAJwXc/r/7GqDl/uByRJkiRJY2DOnDl3OimciVG3OH4CuAnYDNgZOD7JqVU1r7dSVT2l9/skP6VJBgHWBX4L7A9cBry83c+2VbWwrXNRVW25og5CkiRJkmaTkY1xTLIO8FzggKpaWFUnA8cC+yzlddvStD4eAVBVf6uqQ6rq4qq6taoOpWmRvPcKPQBJkiRJmqVGOTnOjsAtVXVGT9mpwE5Led2+wElVdc6gjUl2pkkcz+wp3jTJpUnOTvLhNmkd9NpXJjklySnz58+f6XFIkiRJ0qwyysRxXeCavrIFwHpLed2+wBcHbUgyBzgSOLCqFrTFf6HpBrs5sCfwUOCQQa+vqkOrapeq2mXu3LkzOARJkiRJmn1GmTguBPpHa84Brp3uBUkeBdwd+MaAbWsDxwG/qqr3TJVX1SVVdVpV3VZVZwNvpukiK0mSJEm6E0aZOJ4BrJbkXj1lDwLmTVMfYD/g6J5JbwBIsibwLeAC4FVLed/C9SolSZIk6U4bWUJVVYuAo4GDkqyTZDdgL5qupktoWxSfT1831SSr07RAXg/sV1W39W1/bJJt0tgKeC/w7eV9PJIkSZI0W4y6Je61wNo0y2gcBbymquYl2T3Jwr66zwKuBn7SV/5I4Ok0a0FenWRh+5ha9/HBwC+ARe3XPwGvWwHHIkmSJEmzQqqq6xjGwi677FKnnHJK12FIkiRJUieS/K6qdhm0zbF/kiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUaaOCbZKMkxSRYlOTfJ3tPU+26ShT2Pm5L8qWf7tkl+kuS6JH9J8vi+178xySVJrklyWJI1V/SxSZIkSdLKarURv98ngJuAzYCdgeOTnFpV83orVdVTer9P8lPghJ6io4BfAk9tH99Icq+qmp/kScC/A3sCFwHHAAe2ZZIkSSvcwS95XtchrDT+40vfWO77PP3gE5ZeSTN23//Yc7nv8x3veMdy3+dstjx+niNrcUyyDvBc4ICqWlhVJwPHAvss5XXbArsDR7Tf7wg8BHh7VV1fVd8E/tTuG2A/4PNVNa+qrgLeCbx0+R+RJEmSJM0Oo+yquiNwS1Wd0VN2KrDTUl63L3BSVZ3Tfr8T8Lequnaa/ezUft+7bbMkG9/ZwCVJkiRpNhtl4rgucE1f2QJgvaW8bl/gi337WTBkP/3bp54v8T5JXpnklCSnzJ8/fylhSJIkSdLsNMrEcSEwp69sDnDtgLoAJHkUcHegt3P70vbTv33q+RLvU1WHVtUuVbXL3Llzl3oAkiRJkjQbjTJxPANYLcm9esoeBMybpj404xWPrqqFPWXzgO2T9LYg9u5nXvt977ZLq+qKOx25JEmSJM1iI0scq2oRcDRwUJJ1kuwG7AUcOah+krWB53PHbqq0YyT/ALw9yVpJng08EPhmW+UI4OVJ7pdkA+Bt/fuQJEmSJM3cSNdxBF4LrA1cRrOkxmuqal6S3ZMs7Kv7LOBq4CcD9vNCYBfgKuC9wPOqaj5AVX0PeH/7uvOAc4G3L/cjkSRJkqRZYqTrOFbVlTQJYX/5STST2vSWHUWTXA7azznAY4a8zyHAIXc+UkmSJEnSlFG3OEqSJEmSJoyJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOt1nUAkqTx87M9Ht11CCuNR5/4s+W+z4//y3HLfZ+z2T996BldhyBJY88WR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA21WtcBTKKH/usRXYew0vjdB/btOgRJkiRJS2GLoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGGmnimGSjJMckWZTk3CR7D6n7kCQnJlmY5NIkr2/Lt27Leh+V5F/a7Y9Jclvf9v1GdYySJEmStLIZ9XIcnwBuAjYDdgaOT3JqVc3rrZRkE+B7wBuBbwBrAFsCVNV5wLo9dbcDzgS+2bOLi6pqyxV3GJIkSZI0e4ysxTHJOsBzgQOqamFVnQwcC+wzoPr+wPer6stVdWNVXVtVp0+z632BE6vqnBUSuCRJkiTNcqPsqrojcEtVndFTdiqw04C6jwCuTPKLJJclOS7J1v2VkoQmcTy8b9OmbffWs5N8uE1aJUmSJEl3wigTx3WBa/rKFgDrDai7JbAf8Hpga+Bs4KgB9R5F0+31Gz1lf6HpBrs5sCfwUOCQQQEleWWSU5KcMn/+/BkfiCRJkiTNJqNMHBcCc/rK5gDXDqh7PXBMVf22qm4ADgQemWT9vnr7Ad+sqoVTBVV1SVWdVlW3VdXZwJtpusguoaoOrapdqmqXuXPn3snDkiRJkqSV2ygTxzOA1ZLcq6fsQcC8AXX/CFTP99VfIcnawP9jyW6q/QqXHZEkSZKkO21kCVVVLQKOBg5Ksk6S3YC9gCMHVP8C8OwkOydZHTgAOLmqFvTUeTZwFfCT3hcmeWySbdLYCngv8O0VcEiSJEmSNCuMuiXutcDawGU0YxZfU1XzkuyepLe76QnAW4Hj27o7AP1rPu4HHFlV/a2RDwZ+ASxqv/4JeN0KOBZJkiRJmhVGuo5jVV0JPGtA+Un0rM3Yln0K+NSQfT1pmvJDmGYyHEmSJEnSsnPsnyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGmqk6zhKEsBu/7Vb1yGsVH7+zz/vOgRJkrSSs8VRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ63WdQDS8nbeQQ/oOoSVytb/+aeuQ5AkSVLHbHGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDzShxTPKsJKuu6GAkSZIkSeNnpi2OXwYuTPK+JDuuyIAkSZIkSeNlponj3YG3A48GTk9ycpKXJVlnxYUmSZIkSRoHM0ocq+raqvpMVT0CeCDwa+A9wMVJPpvkESsySEmSJElSd5Z5cpyqmgd8GDgUWAN4AXBSkl8neeByjk+SJEmS1LEZJ45JVk/y/CTfA84G9gReDWwGbAOcDnxthUQpSZIkSerMajOplOS/gBcBBRwJ7F9Vp/VUuT7JvwMXLf8QJUmSJEldmlHiCNwP+Cfg6Kq6aZo6lwOPXS5RSZIkSZLGxowSx6p63Azq3AL87C5HJEmSJEkaKzMa45jk4CSvHlD+6iTvXP5hSZIkSZLGxUwnx9kH+P2A8t8B+y6/cCRJkiRJ42amieOmwPwB5VfQzKoqSZIkSVpJzTRxPA/YfUD5HsAFM32zJBslOSbJoiTnJtl7SN2HJDkxycIklyZ5fc+2c5Jc325bmOQHfa99Y5JLklyT5LAka840RkmSJEnSHc10VtXPAB9OsgZwQlv2OOA9wPuW4f0+AdxE00q5M3B8klOral5vpSSbAN8D3gh8A1gD2LJvX8+oqh/1v0GSJwH/TrPO5EXAMcCBbZkkSZIkaRnNdFbVD7XJ3MdokjhoEsCPVtX7Z7KPJOsAzwXuX1ULgZOTHEszfrI/qdsf+H5Vfbn9/kbg9Jm8D7Af8PmpZLSdvOfLA95DkiRJkjQDM+2qSlW9BdgEeET7mFtVy5KM7QjcUlVn9JSdCuw0oO4jgCuT/CLJZUmOS7J1X50vJ5mf5AdJHtRTvlO739732CzJxssQqyRJkiSpNePEEaCqFlXVb9vHwmV8r3WBa/rKFgDrDai7JU3L4euBrYGzgaN6tr8Y2BbYBvgJ8P0kG/S8z4K+92DQ+yR5ZZJTkpwyf/6guX8kSZIkSTMd40iSxwIvoknk1ujdVlV7zmAXC4E5fWVzgGsH1L0eOKaqftu+94HA5UnWr6oFVfXznrrvSbIfzeQ9xw14n6nnS7xPVR0KHAqwyy671AyOQZIkSZJmnRm1OCZ5KfBdmla7x9AszbEh8BDgtBm+1xnAaknu1VP2IGDegLp/BHoTuaUldQWkfT6v3W/ve1xaVVfMME5JkiRJUo+ZdlV9E/BPVfUi4GbgLVX1YOBLNC18S1VVi4CjgYOSrJNkN2Av4MgB1b8APDvJzklWBw4ATq6qBUm2TrJbkjWSrJXkX2nGXk61Qh4BvDzJ/druq28DvjjD45QkSZIk9Zlp4rg9MLX0xY004wgBPg68dBne77XA2sBlNGMWX1NV85LsnuT2BLSqTgDeChzf1t0BmFrzcT3gU8BVwIXAk4GnTLUoVtX3gPfTjH08DzgXePsyxChJkiRJ6jHTMY5XsHhymQuB+9N0J92YJhGckaq6EnjWgPKTWJyMTpV9iiZB7K87D3jgUt7nEOCQmcYlSZIkSZreTBPHk4AnAn8Cvg58LMkTgMcBP1xBsUmSJEmSxsBME8d/AtZqn78HuAXYjSaJfNcKiEuSJEmSNCaWmjgmWQ14IfAtgKq6DXjfig1LkiRJkjQuljo5TlXdAnwAWH3FhyNJkiRJGjcznVX1V8BDV2QgkiRJkqTxNNMxjp8FPphka+B3wKLejVX1v8s7MEmSJEnSeJhp4viV9uugJS4KWHX5hCNJkiRJGjczTRy3W6FRSJIkSZLG1owSx6o6d0UHIkmSJEkaTzNKHJM8Z9j2qjp6+YQjSZIkSRo3M+2q+o1pyqv96hhHSZIkSVpJzWg5jqpapfcBrAE8HDgJ2GNFBihJkiRJ6tZM13G8g6q6pap+C7wV+OTyDUmSJEmSNE7uVOLY42rgnsshDkmSJEnSmJrp5DgP6S8CNgf+Dfj98g5KkiRJkjQ+Zjo5zik0E+Gkr/xXwMuWa0SSJEmSpLEy08Rxu77vbwPmV9UNyzkeSZIkSdKYmVHiWFXnruhAJEmSJEnjaUaT4yQ5OMmrB5S/Osk7l39YkiRJkqRxMdNZVfdh8CQ4vwP2XX7hSJIkSZLGzUwTx02B+QPKrwA2W37hSJIkSZLGzUwTx/OA3QeU7wFcsPzCkSRJkiSNm5nOqvoZ4MNJ1gBOaMseB7wHeN+KCEySJEmSNB5mOqvqh5JsAnwMWKMtvgn4aFW9f0UFJ0mSJEnq3kxbHKmqtyR5F3C/tuj0qlq4YsKSJEmSJI2LGSWOSe4OrFZVFwC/7SnfEri5qi5dQfFJkiRJkjo208lxvgQ8ZUD5k4Ajl184kiRJkqRxM9PEcRfgxAHlJ7XbJEmSJEkrqZkmjqsBaw4oX2uackmSJEnSSmKmieOvgdcMKP9HesY8SpIkSZJWPjOdVfU/gBOSPJDF6zjuCTyEZj1HSZIkSdJKakYtjlX1K+DvgHOA57SPvwGPAO62ooKTJEmSJHVvWdZxPBV4Mdy+DMfLgGOAbYBVV0h0kiRJkqTOzXSMI0lWTfKcJMcDZwPPAj4N7LCCYpMkSZIkjYGltjgmuTfwD8C+wCLgKzTrN+5TVaet2PAkSZIkSV0b2uKY5CTgV8CGwPOravuqehtQowhOkiRJktS9pbU4/h3wCeDQqpo3gngkSZIkSWNmaWMcH0aTXJ6c5PdJ3pjk7iOIS5IkSZI0JoYmjlX1+6r6R2Bz4BDgmcD57euelmTDFR+iJEmSJKlLM13H8YaqOrKqHgvcF/gA8EbgkiTfXZEBSpIkSZK6NePlOKZU1ZlV9e/AVsDzgZuWe1SSJEmSpLGxzInjlKq6taq+XVV7zfQ1STZKckySRUnOTbL3kLoPSXJikoVJLk3y+rZ80yRHJbkoyYIkP0/y8J7XPSbJbe3rph773dnjlCRJkqTZbqnrOC5nn6BpodwM2Bk4Psmp/TO2JtkE+B5Nd9hvAGsAW7ab1wV+C+wPXAa8vN3PtlW1sK1zUVVtiSRJkiTpLrvTLY7LKsk6wHOBA6pqYVWdDBwL7DOg+v7A96vqy1V1Y1VdW1WnA1TV36rqkKq6uG31PJQmsbz3qI5FkiRJkmaTkSWOwI7ALVV1Rk/ZqcBOA+o+ArgyyS+SXJbkuCRbD9ppkp1pEscze4o3bbu3np3kw23SKkmSJEm6E0aZOK4LXNNXtgBYb0DdLYH9gNcDWwNnA0f1V0oyBzgSOLCqFrTFf6HpBrs5sCfwUJqlRJaQ5JVJTklyyvz585f1eCRJkiRpVhhl4rgQmNNXNge4dkDd64Fjquq3VXUDcCDwyCTrT1VIsjZwHPCrqnrPVHlVXVJVp1XVbVV1NvBmmi6yS6iqQ6tql6raZe7cuXfp4CRJkiRpZTXKxPEMYLUk9+opexAwb0DdPwLV833vc5KsCXwLuAB41VLetxjtcUqSJEnSSmVkCVVVLQKOBg5Ksk6S3YC9aLqa9vsC8OwkOydZHTgAOLmqFrTff4OmVXK/qrqt94VJHptkmzS2At4LfHsFHpokSZIkrdRG3RL3WmBtmmU0jgJeU1XzkuyeZGopDarqBOCtwPFt3R2AqTUfHwk8HXgicHXPWo27t9sfDPwCWNR+/RPwuhV+ZJIkSZK0khrpOo5VdSXwrAHlJ9FMntNb9ingUwPq/gzIkPc4hGkmw5EkSZIkLTvH/kmSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYaaeKYZKMkxyRZlOTcJHsPqfuQJCcmWZjk0iSv79m2bZKfJLkuyV+SPL7vtW9MckmSa5IclmTNFXlckiRJkrQyG3WL4yeAm4DNgBcDn0qyU3+lJJsA3wM+A2wM7AD8oKfKUcDv223/AXwjydz2tU8C/h14HLANsD1w4Ao6HkmSJEla6Y0scUyyDvBc4ICqWlhVJwPHAvsMqL4/8P2q+nJV3VhV11bV6e1+dgQeAry9qq6vqm8Cf2r3DbAf8PmqmldVVwHvBF66Qg9OkiRJklZio2xx3BG4parO6Ck7FViixRF4BHBlkl8kuSzJcUm2brftBPytqq6dZj87td/3btssycbL5SgkSZIkaZYZZeK4LnBNX9kCYL0BdbekaTl8PbA1cDZN99Sp/SwYsp/+7VPPl3ifJK9MckqSU+bPnz/Dw5AkSZKk2WWUieNCYE5f2Rzg2gF1rweOqarfVtUNNGMUH5lk/Rnsp3/71PMl3qeqDq2qXapql7lz5y7TwUiSJEnSbDHKxPEMYLUk9+opexAwb0DdPwLV833v83nA9kl6WxB79zOv/b5326VVdcWdDVySJEmSZrORJY5VtQg4GjgoyTpJdgP2Ao4cUP0LwLOT7JxkdeAA4OSqWtCOkfwD8PYkayV5NvBA4Jvta48AXp7kfkk2AN4GfHEFHpokSZIkrdRGvRzHa4G1gctoxiy+pqrmJdk9ycKpSlV1AvBW4Pi27g5A75qPLwR2Aa4C3gs8r6rmt6/9HvB+4CfAecC5wNtX8HFJkiRJ0kprtVG+WVVdCTxrQPlJNJPa9JZ9CvjUNPs5B3jMkPc5BDjkzkcqSZIkSZoy6hZHSZIkSdKEMXGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShhpp4phkoyTHJFmU5Nwke09T7x1Jbk6ysOexfbtt977yhUkqyXPb7S9Ncmvf9seM7iglSZIkaeWy2ojf7xPATcBmwM7A8UlOrap5A+p+rape0l9YVScB60593yaFxwHf66n2y6p61PILW5IkSZJmr5G1OCZZB3gucEBVLayqk4FjgX3u4q73A75RVYvuaoySJEmSpCWNsqvqjsAtVXVGT9mpwE7T1H9GkiuTzEvymkEV2mT0ecDhfZsenOTyJGckOSDJqFtWJUmSJGmlMcqEal3gmr6yBcB6A+p+HTgUuBR4OPDNJFdX1VF99Z4DXA78rKfsROD+wLk0SenXgFuA9/S/SZJXAq8E2HrrrZfxcCRJkiRpdhhli+NCYE5f2Rzg2v6KVXVaVV1UVbdW1S+Aj9K0LPbbDziiqqrntX+rqrOr6raq+hNw0DSvpaoOrapdqmqXuXPn3snDkiRJkqSV2ygTxzOA1ZLcq6fsQcCgiXH6FZDegiRbAY8BjljW10qSJEmSZm5kiWM7ec3RwEFJ1kmyG7AXcGR/3SR7JdkwjV2B1wHf7qu2D/CLqjqr77VPSbJZ+/w+wAEDXitJkiRJmqGRruMIvBZYG7gMOAp4TVXNm1qbsafeC4EzabqxHgG8r6r6J8DZlyUnxQF4HPDHJIuA/6FJVt+9fA9DkiRJkmaPkc42WlVXAs8aUH6HtRmr6kUz2Nd9pil/E/CmOx+lJEmSJKnXqFscJUmSJEkTxsRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI0lImjJEmSJGkoE0dJkiRJ0lAmjpIkSZKkoUwcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjSUiaMkSZIkaSgTR0mSJEnSUCaOkiRJkqShTBwlSZIkSUOZOEqSJEmShjJxlCRJkiQNZeIoSZIkSRrKxFGSJEmSNJSJoyRJkiRpKBNHSZIkSdJQJo6SJEmSpKFMHCVJkiRJQ5k4SpIkSZKGMnGUJEmSJA1l4ihJkiRJGsrEUZIkSZI01EgTxyQbJTkmyaIk5ybZe5p670hyc5KFPY/te7ZXu4+pbZ/r2ZYk70tyRft4X5KM4vgkSZIkaWW02ojf7xPATcBmwM7A8UlOrap5A+p+rapeMmRfD6qqMweUvxJ4FvAgoIAfAmcDn74LcUuSJEnSrDWyFsck6wDPBQ6oqoVVdTJwLLDPcn6r/YAPVdUFVXUh8CHgpcv5PSRJkiRp1khVjeaNkgcDP6+qu/WUvQl4dFU9o6/uO4A3ArcCFwMfr6pP9WyvtnwV4BfA/lV1TrttAfDEqvp1+/0uwE+qar0BMb2SpoUS4N7A/y2Xgx0fmwCXdx2EpuX5GX+eo/Hm+Rl/nqPx5zkab56f8beynaNtqmruoA2j7Kq6LnBNX9kCYImEDvg6cChwKfBw4JtJrq6qo9rtjwZ+BdwNeBfwnSQ7V9Ut7fss6HuPdZOk+rLkqjq0fZ+VUpJTqmqXruPQYJ6f8ec5Gm+en/HnORp/nqPx5vkZf7PpHI1ycpyFwJy+sjnAtf0Vq+q0qrqoqm6tql8AHwWe17P9xKq6qaquBl4PbAfcd5r3mQMs7E8aJUmSJEkzM8rE8QxgtST36il7EDBoYpx+BQybGbV3+7x2v8v6HpIkSZKkAUaWOFbVIuBo4KAk6yTZDdgLOLK/bpK9kmzYLq2xK/A64Nvttp2S7Jxk1STr0kx+cyFwevvyI4D9k2yR5B7AvwBfXNHHN6ZW2m64KwnPz/jzHI03z8/48xyNP8/RePP8jL9Zc45GNjkONOs4AocBTwCuAP69qr6SZHfgu1W1blvvKOCJwJrABcAnq+pj7bY9gU8BWwKLaCbH+deq+mu7PcD7gH9o3/ZzwL/ZVVWSJEmS7pyRJo6SJEmSpMkzyjGOkiRJkqQJZOIoSZIkSRrKxFEagXYyp7OSrNl1LNKkan+PDvf3aDy15+cgz894S+K1n3QnzfbrOf94SCNQVbcCtwJrdR2LBmv/Gfx0tv4zmATt79ETgdu6jkVLas/Pa4Gbu45FgyVZFVjk37nx5f+i8Tbbr+dMHFcySVZPsnuSF7Tfr5Nkna7jEgAfAb6e5NFJ7plk+6lH14Hp9n8G2+HfxXH3YeDAJKt3HYgGOgJ4dddBaLD279wZwMZdx6LB/F80ET7CLL2ec1bVlUiSBwDHAjcCW1bVukmeCuxXVS/oNjolma6VpKpq1ZEGo4GS/D2wB/B2mqWAbv8DWVW2co2BJOcDd6e54zufO56jrbuKS40kJwMPp1lf+XzueH726CouLZbkzcALgY+y5N+5E7qKS4v5v2i8zebrORPHlUj7D/szVXVkkquqasO2tfGMqtqi6/ikcdfzz6D3D2OYBf8MJkWSR0+3rap+NspYtKQk+023raoOH2UsGizJ2dNsqqpa6VtMJoH/izSuTBxXIkmuAjaqqkpyZVVt1Jbf/lzdS7I1sAVwQVWd33U8WizJNtNtq6pzRxmLNImSrNp2tZN0J/m/aDLMxus5+0+vXM4BHtpbkGRX4MxOotEdJNk8yc9ozsfRwFlJTkxyj45D02IbVtW5gx5dB6ZGO477wCR/S3JD+/XAJGt0HZsAuCTJJ5Ps1nUgml6S1ZLskeRF7bwIq3Udkxbr+b9zPnATcL7/i8bHbL6eM3FcuRwAHJ/kQGCNJG8B/ht4W7dhqfUp4FSa5GRzYEPg98CnO41KvX6QZF6St82GQe4T6v3A42kmYHlQ+3VP4H1dBqXbPRFYCByV5Owk72nH32tMJLkPcDrwFeB1wFHAX5Lct9PAdLskc5IcAdxAM174+nYpovU7Dk2NWXs9Z1fVlUySBwOvALahuVP12ar6XbdRCSDJ5cDmVXVzT9mawIVVtUl3kWlKO1X9k4EXAc8E5tFcXH2tqi7rMjY1klwAPKiqrugp2wQ41bHc46Udj/oi4LnAxVX1wI5DEpDkBOC7wAervQhM8ibgaVX12E6DEwBJvgisB7wFOJfmmu5g4LqqmnYcsUZjNl/PmThKI5Lkr8DzqurUnrIHAkdX1Q7dRaZBkqwN7AW8BnhEVbmm1hhIciHwwAGJ4x+raqXvJjRJkmxGM3vnvsC9qmpOxyGJZt4DYG7vWNS2q+r8qtqwu8g0JcklwPZVdV1P2brAWVW1WXeRCWb39Zx92lciSQ6aZtONNNM5f6+qLh1hSLqj9wM/SvJ5Ft9BfBlNF2ONkSRrAU8HXgDsApzUbUTq8d/AcW2X/PNofo/eBny906gEQJINaFoY9wYeAfyAphvxsR2GpTu6CHg00Lv0xu5tucbDDcBcmmuFKZvQXM+pe7P2es4Wx5VIkq8CzwZ+Q9NNdStgV+A4YEvgAcBzq+p7nQU5yyXZk+aC6h40/6SPqqofdxuVprTrnu5N0031NOCrwFer6pJOA9Pt2klw3kbf7xHwrqryoqpjSa4DfkFzTr5ZVVd3G5H6JXkmTRf879Bc9G4LPBV4SVV9u8PQ1EryNpqW+kNYnJi8ETiyqt7VZWxqzNbrORPHlUiSr9N8cI/pKdsL2LuqXtCur/XGqtq5qxilcZbkNJoL3q9U1VldxyNNmiR7A7+qqr8luTtNa+NtwFu8ATM+kuwIPJ/FF71fr6ozuo1KU5KEpgWr/wbZYeWFuzpk4rgSSbKAZh3H3nELqwJXVdWc3uedBTmLJdkfOKGq/pDk4TRd7m6lSex/2W100mRI8ljgnKo628Rk/CQ5HXhSVZ2X5Ctt8fU0Y+qe2WFomkY7nvs2W+ylmZnN13Mux7FyOYtmIo9er27Loekffx3qyhuBs9vn76XpgvIu4CNdBaQ7SrJ/kp3b549Icl67pMDfdRyaFvskzT9oaH6HVqdJHA/tLCL12qJNGlcDngS8kub/0iO7DUtTknywXeOZJE8DrgSuSvKMbiPTlHZ9zfu2z3dM8rMkP2mXUlH3Zu31nC2OK5EkD6FZiHRVmnV/tqC5wHpOVf1vkj2Ae1fVZzsMc9ZKck3b8rsezZiFuVV1a5Krq2qDjsMTkOR84P5VtSDJT4BvA9cCr6yqh3cbneAOv0erAZfSjP25CbhoZZ8GfRK0y6U8FLg/8I6q2r0dlzq/qlyDbgwkuRi4Z1Vdl+TXNBN9LAA+XFWuuTkGkpwFPLKqLk1yHPB/NOuj7lFVe3YbnWbz9Zyzqq5E2uTwXsDfAZsDFwO/nFpnpqpOBE7sMMTZ7vwkjwR2Ak5s/8jMYXHribq3fps0rkezuPzj2/P0oa4D0+2uaZd5uD9wWlUtbBOT1TuOS43/An4LrAG8oS3bDfhLVwFpCXdrk8aNaZZ8+CZAkm06jkuLzW2TxrWARwHPA24GLu82LLVm7fWcieNKpk0STQ7H078C36BpHXluW/Z0mllwNR5m7T+DCWJiMsaq6n1JjgFu7Zlg6kLgHzoMS3d0RpIXAzsAP4Tb10K9vtOo1Gt+kh1oZsP/bVXdmORuQDqOS41Zez1nV9UJ13atW+pJrKqtRxCOllGS1eH2hF8dS/IU4PO0/wyq6nftLJH7VNVTuo1OU9oZIW9PTNrv16yqP3UbmTT+kjwM+CjN37mXV9VZbSL55Krap9voBJDkpTTn6FbgBVX1w3YZlf2r6jFdxqbBZsv1nInjhEvy6J5vHwbsB3yMxev+/BNwRFXZ1a5jSe4HXNF2P1mX5o7VbcAHqspJizqWZBXgMcDPe2cXnC3/DCZVO8vqbVX1s65jkaTlpW1hZOr6IMmmwCrOHt292Xw9Z+K4EknyZ5pp0C/sKdsS+F5V3b+7yASQ5FTg+VX1f0k+DdwbuAG43Lu84yHJtVW1XtdxaHpJfga8tap+nuTfgP2BW4BPVNW7u41OGn99S9psTjMrpEvajJEkc4Hr2zHcqwL70pyjI6vqtm6j02y+njNxXIkkuRLYrqoW9JRtAJxdVRt2FpiAZp3Nqlq/Xdj3UuB+NGNKzq6qTbuNTgBJjgfeWVW/6joWDZbkCmDTdvzpmcAzaWa+/bld8qWlc63N8dfOdvvqqvp9kvcCz6CZHOcnVfXGbqPTbL6ec3KclcuxwLFJ3gVcAGwFvKUtV/duaGfrvB9wXlVd3i4psFbHcWmxc4HvJvk2cIfxw1X1n51FpV6rAJXknjQ3P08DSOLNMWlm+tfavH1Jm27DUo8dgT+0z19Csw7qQmAezRqC6tasvZ4zcVy5vBp4B/Bp4B40y3F8HTiww5i02FeAE4D1gI+3ZQ9h8SKy6t7awLfa51t2GIemdzLN78/mwDEAbRLpNPXSzLikzfi7FVijnfhrQZvorwKs23Fcasza6zm7qkojlOSJwM1V9ZP2+12AOVV1QreRSZOhXXvuX2i6bX2gveh9GnCvqvpIp8FJE6AdG/yPtEvaVNVX23GP762qh3cbnQCSHAnMATYGvl9V70xyf+AbVXWfbqMTzN7rORPHCZdkj6o6sX2+53T1VvYP8iRJshVNVyHH0Y2ptgvKJvSsmVVVf+suIklaflzSZrwlWZNmlvybaSbEuSXJY4C7V9VXu4xNi83G6zkTxwmX5M9TM6a2azreMqBaVdX2o41M/ZJsDRwF7ExzTtZN8jyatbNcHHsMtFNsfxl4EM34xrRfqapVOwxNrfaC6j+BFwEbtxMUPBHYsao+PvzVkuD2ZYYeAdyjqr6WZB2AqlrUbWTq1XZP3ayqLu46Fi02m6/nVuk6AN01PUnjqsBc4D5VtV3fw6RxPHwGOJ6mT/zUmoA/BJ7QWUTq90ngJ8BGwDXAhjTnbb8ug9IdfJhmbNaLWTx50TzgNZ1FJE2QJA8AzgA+C3y+LX40cFhnQekOkmzQznh7A3BmW/bMdvJDdW/WXs/Z4rgSadeVeUpVOTPaGGqXEZhbVbclubKqNmrLr66qDbqNTgBJrqJZ6uHmqfPS3on/c1Vt13V8giQXAztU1SJ/j6Rll+Rk4DNVdWSSq6pqw/bv3BlVtUXX8QmSfBW4CjiIZgKjDdu1HX9RVffqNjrN5us5Z1VduXwZ+E6Sj9Isx9G7lIBjHLt3KbADzZ1e4Pauked1FpH63UAzs+DNwOVtd5SraCYo0Hi4ib7/Xe0F1RXdhCNNnJ2AL7XPp7riL0qydnchqc/jaLoR35xk6hzNT7JSrxE4QWbt9ZyJ48plqqvWO/rKC7C7avc+SJPYvwdYLcmLgLcC7+02LPU4CXg+8EXgG8B3gRtppt3WePhv4PAkbwRIsjnwEcAJI6SZOQd4KHDKVEGSXWm7RGosLKCZoO32sY3tjUzHOo6HWXs9Z1dVaYSS7AW8imbB5fNougt9q9OgNFA7KcHeNGMYjnDSiPHQrjf3PuAVwN2A62jGav1bVd3UZWzSJEjydJqxjZ+mWdrmYJp1oF9RVT/oMjY1kvw78EzgP2jWq30K8G7g2y47NB5m6/WciaM0Au3kRT8GnlRVN3Ydj4ZzJrvx1P4evR04uKpubLuoXl7+I5OWSZIH09x82QY4H/hsVf2u26g0JUmA19GXmAAf9e9dt2b79ZyJozQiSc6lmfX2+q5j0WBJNgQ+ATyPZmHfdZI8E9i1qt7WbXQCSHI5zQRGt3UdizRp2oveM4D7zcaL3knQnqPDgFd6jsbTbL6eczkOaXQOBD6VZJskqyZZZerRdWC63adoxpZsQzMJC8AvgRd0FpH6HUHTrU7SMqqqW4FbgbW6jkWDtefoiYA3x8bXrL2es8VRGpEkU/8Een/pQrN4rIvLj4Ek81k8k13vFNsLqmr9jsMTty8l8HDgQpoudr2zR+/RVVzSpEjyWmAvmjFz/TOw/62ruLRYkjcDGwDvcOz2+JnN13MmjtKIJNlmum1Vde4oY9FgSc4Edq+qi6cSx3Ymux9U1X26jk+QZL/ptlXV4aOMRZpEPRe9/Vb6i95JkeR84O40rcPzuWNyv3VXcakxm6/nXI5DGpGV/Y/JSuJzwDeT/AewSpK/o7kr/+luw9IUk0Pprqmqlb473UrgJV0HoOnN5us5WxylEUlyJHfs1jDlRpruQt+qqlNHG5V6OZPd+Evy99Nsmvo9+pUTSkiSVpTZfD1n4iiNSJKPA/sAx9KMzdoKeAbNwuUb0KzZ9OqqOqKrGKVxl+SnwN8Bl9L8g94S2IxmMfNt22p7VdUpg14vzXZJTmL4Re/RVXXcaKNSryQHTbNp6hx9r6ouHWFI6jGbr+fsqiqNzo7AU6vq51MFbVfIg6rqCUmeDHyEZtZIdSTJvYEHAev2llfVYd1EpD7zaC5sPzZVkOSfgPsAj6JZMPu/aJJLSUv6KbAfcDiLL3r3Bb5CM8HHYUk+UFXv7yxC7Qg8G/gNi8/RrsBxNAnKJ5M8t6q+112Is9qsvZ6zxVEakSQLgI2r6paestVpFjBfv+0meW1VrTvtTrRCJXkr8J/AqcB1PZuqqvbsJir1SnIVze/RbT1lq9L8Hm2YZE3gMmfBlQZL8mvgpVV1ek/ZfYDDq+rhSXYFjqqqe3YW5CyX5Os05+CYnrK9gL2r6gXtJGFvrKqdu4pxNpvN13MOkJZG5w/AwUnWAmi/vpMmSQHYDriym9DUegOwa1U9vKoe2/MwaRwfl9Lcce/1NOCy9vlawM0jjUiaLPcB+pfdOBe4N0BV/Yam+7e68ySabpC9vgM8pX3+JWD7kUakXn9gll7PmThKo7MfsDtwTZJLgGuAPdpygI2A13YUmxrXA3/pOggN9TrgiCQ/T/LVJD8HjgT+ud3+cJquqpIGOxH4QpIdkqyVZAfgs8DJAEkeAFzcZYDiLOA1fWWvbssBNuGOvWI0WrP2es6uqtKIJdkKuAdwcVWd13U8WizJvsBuwDtoWrZu19s1Ut1KsgnNnfd70FzgHl9VV3QblTQZkmwEfBJ4Ds1cFzcDRwP/XFWXt+O813OCqe4keQjNOVkVuBDYgmZNx+dU1f8m2QO4d1V9tsMwZ73ZeD1n4iiNUJKNgacCm1fV+5PcA1ilqi7oODRxh4Wxe/8wBhfGHjvtP+wtqupXXcciTaIkqwBzgfneGBs/7Zi5R7D4Btkvq8pu+GNitl7P2VVVGpEkjwb+D3gxcEBbfC/gU50FpX7btY/tex5T32sMJNm67Z76F+BHbdnzknyu28ikydFOhvMfwAFVdVuSeyd5YNdxabCqOhFYI8k6Xcei2X09Z4ujNCJJfg+8qap+nOSqdgbItYBzq8qJCKQZSPJd4CTgvcAV7e/R+sAfq2qbbqOTxl+S/0fTVfWbNLN0zkmyC/Deqnp8t9EJbh9neizNuo1bVtW6SZ4K7FdVL+g2Os3m6zkTR2lEpv64tM+vrKqN2q5C86tq447Dm7WSHFpVr2yfH8nghbGpqn1HGpgGSnIFMLdtJbmyqjZqy6+uqg26jU4af0lOB15YVaf2XPSuDlxUVXO7jk+Q5GTgM1V1ZM85Wgc4o6q26Dq+2W42X8+t1nUA0ixyWpInVdX3e8oeD/ypq4AEwNk9z8/sLArN1KXADsAZUwVJ7gfMiokJpOVgU+CP7fPq+WpLwvjYiWbJDWjPS1UtSrJ2dyGpx6y9njNxlEbnX4DvJDkeWDvJZ2jWo9ur27BmvV8nmVqn8aROI9FMfJDm9+g9wGpJXgS8labrqqSl+x2wD3BET9kLgd90E44GOAd4KHD7zLZJdsWbm+Ni1l7P2VVVGpG2G8PdgZcA2wDnA19a2WfgGndJzl56LaqqnCBnTCTZC3gVze/ReTRdur7VaVDShGgnxvkBTW+LRwA/BXYEnlhVf+0wNLWSPB34PPBpmiTlYJp1HF9RVT/oMjbN7us5E0dpBJKsCiwENqiqG7uOR5pE7e/Rj4En+XskLbskoZkp+nLgySy+6P1OVS3sMjbdUZIHA69g8Tn6bFX9rtuoNNuv50wcpRFJcirwlKq6qOtYpEmV5FzgPlV1fdexSJMoySJgPdduHE9tYnIGcL/ZmJhMgtl8PecYR2l0vkzTJ/6jwAX0TERQVSd0FpU0WQ4EPpXk7Sz5e+SFsLR0v6fpmvqXrgPRkqrq1iS3AmvRLMeh8TNrr+dscZRGZMhYOsfPSTOUZCo57P3nFZrfo1U7CEmaKEneRTM264s0XSB7L3oP6ygs9UjyWpqJVt7NkonJ37qKS43ZfD1n4ihJmhhJtpluW1WdO8pYpEmU5CfTbKqq2nOabRqhnhtk/bxBpk6ZOEojkuTbVbXEVM1Jjq6q53QRkyRJkpZNktWARwJb0LQK/7Kqbuk2qhXPxFEakSTXVNWcAeVXVtVGXcQkTZokRzJ4ofIbaf55f6uqTh1tVNLkSDIXuL6qFrYTsewL3EqznIDjhKWlaJe0OQ5Ym6a791bADcAzqur0LmNb0ZwcR1rBkhzUPl2j5/mU7QG710kzt4Bm8fJjWfwP+xnAV4H7Av+W5NVVdcT0u5Bmte/QrAn4e5oxdE8HbgYeDLyxw7jUSnISw2+QHV1Vx402KvX4JHAo8MFqW+CSvKktf2yXga1otjhKK1iSL7RPX0wzE9eUAi4FPl9VZ448MGkCJfkBcGBV/byn7O+Ag6rqCUmeDHykqu7TWZDSGEtyFbBRVVWSC2i62y0E5lXV5t1GJ4Ak7wT2Aw5n8Q2yfYGv0EwG9nLgA1X1/s6CnMWSXAnMrapbe8pWA+ZX1YbdRbbimThKI5LkFVX12a7jkCZZkgXAxr1jSZKsDlxeVeu3C5xfW1XrdhakNMaSXE4zLmtH4KtVtVOSVYAFVbVet9EJIMmvgZf2dntsu0ceXlUPT7IrcFRV3bOzIGexJH8GXte79EaSxwIfr6qduotsxbOrqjQ6P0+yWVVdmmRd4F+B22juGl7XcWzSpPgDcHCSt1fVDUnWAt4BTI1r3A64sqPYpEnwXeDrwMY0XbwB7gdc2FlE6ncfoH/ZjXOBewNU1W+SbDbyqDTlrcCxSb5Dc162AZ5Gs8zNSm2VrgOQZpGjgA3a5x8E9gAeAXymq4CkCbQfsDtwTZJLgGtofpf2a7dvBLy2o9ikSfAPwPHA54H3tGWb0NyA0Xg4EfhCkh2SrJVkB+CzwMkASR4AXNxlgLNZVR0LPAT4M7Be+/WhVfXtTgMbAbuqSiOSZEFPV7pLae7wXg+cXVWbdhudNFmSbAXcA7i4qs7rOh5p0rTdUzerKhOQMZNkI5qJVp4DrArcAhwN/HNVXZ7k3sB6VXVKh2FqFjJxlEYkyaXADjQJ4yeqapd2MPWVg5bpkDS9JJsCdxjHWFX9Xbsk9UmyAU1S8jzg5qpaJ8kzgV2r6m2dBqc7aJP7uTSTrrhUSoeGLAV1B1W17wjC6YxjHKXR+QpwAk23ho+3ZQ8Bzu4sImnCtLOmfh7on/2xaO7MSxru08BVNOOyTmvLfgl8CDBxHBNJ1qcZ07hu+z0AvROyaKSc/R5bHKWRSvJEmju8P2m/3wWY4z8CaWaSnAV8gGZ2weu7jkeaNEnmA/eoqpuTXFlVG7XlC6pq/Y7DE5DkpcAnaJZJ6Z08r6pq+06C0h0keQLwImDTqnr6bLmes8VRGqGq+kGSrdt15y50fIK0zDYEPlPe9ZTurAU0k+HcPrYxydY42co4ORh4XlV9t+tAtKQk/wy8Hvgc8Ny2+HrgYzTroq60nFVVGpEkmyf5GfBXmkHuZyb5WZJ7dByaNEk+D7ys6yCkCfY54JvtunOrtDcyD6fpwqrxsBrwg66D0LTeADy+qt5Ls6wawF9ol0tZmdlVVRqRJN8CzgPeUlWLkqwDvBvYrqqe2Wlw0oRIchKwK83aWZf0bquqPToJSpog7czerwNeRTPO8TyaZaE+akv+eEiyP818CO90Upzxk+QyYPOqunWqu3e7pvDZVdU//n6lYuIojUiSy2n+0NzcU7YmTZfVTbqLTJocSfabbltVHT7KWCRpRUhyPnB34Cbgit5tVbV1J0Hpdkm+Afy+qg7uSRzfDOxcVXt3Hd+KZOIojUiSv9KMWTi1p+yBwNFVtUN3kUmSZpN2Yo8X0kzs8YzZMrHHpEjy6Om2VdXPRhmLlpRkc+A4mrHCWwB/A64Fnl5Vlwx77aRzchxpdN4P/CjJ52m62W1DM1brgE6jksZckn2q6sj2+d9PV6+qDhtdVNJk6pvY43lt8ayY2GNSmByOt6q6OMnDgIfRXMudD/xmNnQrtsVRGqEkewJ7A/cALgKOqqofdxuVNN6S/E9VPbV9/pNpqlVV7TnCsKSJ1C5p87iqOifJVVW1YZJVgcuqauOu45utkvxHVR3cPj9ounpV9Z+ji0q6I1scpRFquwHZFUhaBlNJY/v8sV3GIq0E1qNpIQGYaj1YnWY8nbqzZc/zrTqLQhrCFkdpRJKsDrwN2IfFLY5HAgdXlf+wpRlI8vuqevCA8lOqapcuYpImyWye2EPSXWPiKI1Ikg/TLCNwIIvHOB4AnFJVb+wyNmlSJLm2qtbrKwtwRVVt1FFY0sSYzRN7TIqphH5A+WVVtWkXMUlg4iiNTJILgAdV1RU9ZZsAp1bVFt1FJo2/JEe0T18AfK1v87Y0/892H2lQ0oRJsgrwGOCXwAOYZRN7TIppbpCtDlziOFR1yTGO0uhkGcslLXbWNM8L+Dnw36MNR5o8VXVbkm+3Sclv2ofGRJKTaP6mrZXkxL7NWwK/GH1U0mImjtLo/DdwXJIDgfNo7vS+Dfh6p1FJE6CqDgRI8quq+n7X8UgT7MQkj6iqX3UdiJbwOZqbyQ8DPt9TXsClOLmeOmZXVWlEkqxBkyjeYTkO4F1VdWOXsUmTIsljgXOq6uwkdwfeB9wGvMXxWdLSJfkk8CLg2zTdVG+/EHSph/GQ5D5V9Zeu45D6mThKkiZGktOBJ1XVeUm+0hZfD8ytqmd2GJo0EZJ8YbptVfWyUcaiwZK8CPhDVZ2e5N7AoTQ3yF5jQqkumThKI5RkT5o7vVMtjl+tqh93G5U0OZJcU1VzkqxG03VrG5r15y6qqk26jU6S7rokZwGPrKpLkxwH/B+wENijqvbsNjrNZqt0HYA0WyT5F+CrwJXA8cAVwFfackkzc02SzYBHA6dV1cK2fPUOY5ImRpIrpym/bNSxaFpz26RxLeBRwH8ABwE7dxqVZj0nx5FGZ39gz6r681RBkiOBHwIf6iwqabL8F/BbYA3gDW3ZboDdt6SZWeImS7vUw6odxKLB5ifZgWbJlN9W1Y1J7oazsKtjJo7SaJ3Z9/3f6JmYQNJwVfW+JMcAt1bV1LIcFwL/0GFY0thzqYeJ8k7gd8CtNGvXAjweOLWziCQc4yitUO1iy1NeTrPw8juAC4CtgAOAn1XV50YenDSh2vGNjwS2oEkaf1FVt3QblTTekuxH02L1KeDVPZtuX+qhqm7uIjYtqW1hpKqua7/fFFjF2aPVJRNHaQVKchuLWxR7u5j0llVV2UVImoEk9wGOA9amWUpgK+AG4BlVdXqXsUmTwKUeJkOSDYFnsPgG2XeqauD4VGlUTBylFSjJNjOpV1XnruhYpJVBkhOA7wIfrPYfWJI3AU+rqsd2Gpw0IdoJpnYFNqHnpmZVHdZZULpdkr+jmUTvL8C5wNbAfWn+zv2yy9g0u5k4SiOS5E1V9cEB5ftX1SFdxCRNmnZGyLlVdWtP2WrA/KrasLvIpMmQ5FnAl4C/AjsB84D7Ayd782U8JPk18OGq+mpP2QuAN1XVw7qLTLOdy3FIo/Of05S/baRRSJPtIpqlOHrt3pZLWrp3AS+rqgcDi9qvr6SZjEXjYUfg631l3wB26CAW6XbOqiqtYEmmFutdNcljueNYx+2Ba0cflTSx3gocm+Q7NF24tgGeBryk06ikybF1Vf13X9nhwCXAmzqIR0v6K/BC4Cs9Zf8POGtwdWk07KoqrWBJzm6fbg2c17OpaP5Rv7eqjh15YNKESrIj8HzgHjQtjV+vqjO6jUqaDEnOBHZrF5j/PfBa4HLgV1W1cbfRCSDJI4HvAGfQ3CDbFrgX8PSqctkUdcbEURqRJEdU1b5dxyGtDNqlbjYDLq2q27qOR5oUSf4NOLOqvplkX+BQ4DbgQ1V1QLfRaUo7q+rTWHyD7H+cVVVdM3GUJE2MJHOAj9Msir0acAvwVeB1VbWgy9ikSZBkld6bLUm2BtZxOZvx056bLYALq+q8pdWXVjQnx5FGJMmcJIck+V2Sc5OcN/XoOjZpgnwMWAd4AHC3nq8f6zIoaRIkWRVYlGTNqbKqOs+kcbwk2TzJz2jGOh4NnJnkxCT36Dg0zXImjtLofBJ4CHAQsBHwzzRjHj/cZVDShHkysE9VnVFVN7ZjG1/Wlksaol3G5gzAsYzj7VPAqcBGVbU5sCHwe+DTnUalWc+uqtKIJLkMuG9VXZHk6qraIMkWwHFV9ZCu45MmQZJzgEdX1bk9ZdsCJ1bV1l3FJU2KJG+mmbHzo8AFNBO1AVBVJ3QVlxZLcjmweVXd3FO2Jk2X1U26i0yznctxSKOzCjA1BmthkvWBi3FdJmlZfA74YZJDWLwcxxtpJviQtHSvab++o6+8aJaIUveuAu5H0+o45d7A1Z1EI7VMHKXROZVm4fIfAyfRdF1dSNNtSNLMHEwzw+DeLJ5t8P3AYV0GJU2Kqtqu6xi0VO8HfpTk8yy+QfYywFlv1Sm7qkojkmR7gKr6W5JNgXcD6wIHOjGBJGkUkny7qvYaUH50VT2ni5i0pCR7cscbZEdV1Y+7jUqznYmjNCJJPgZ8tXfx3naR3+dX1Rs6C0yaMEn+HngRiy+ovgocVv5Dk5YqyTVVNWdA+ZVVtVEXMUmaDCaO0ogkmQ9sUVU39ZStCZxfVZt2F5k0OZK8H9gL+AiLu3C9jmaSqTd3GJo01pIc1D59M01XyF7bAztV1YNHG5UGSbIG8DaWvEF2cFXd0GVsmt0c4yiNTrHkEjirDiiTNL2XAg+pqgumCpJ8B/hfmgtiSYNt1X5dpec5NP+bzmfJyXLUnU/RTIbzOhbfIHsrsAXw9x3GpVnOFkdpRJJ8EzgbeHNV3ZZkFeC9wL2q6tndRidNhiRn0SSOC3rKNgB+V1X37CwwaUIkeUVVfbbrODS9JFcA96yqq3vKNgLOtDuxumSLozQ6rwe+A1yc5Fxga5rlOJ7RaVTSmJuaWKr1EeDoJO+lWYNuK+BfgQ93EJo0ia7vL0gS4N+r6j0dxKMlXQLcjTsuv7E2zTWD1BlbHKURalsZd6W52D0f+E1V3dZtVNJ4S3IbTXe6DKlWVbXqiEKSJlaSv9J07X51VV3V3pg5EritqnbvNrrZq51FdcquNDOq/heLb5D9I/CVqnpfB+FJgImjJEnSrJFkHZqW+ycDXwReC3wQeJ83MruT5OwZVKuq2n7p1aQVw8RRkjQxknysql43oPwjLmsjzUySucCPgfsDhwN/73I2kpbG2RwlSZPkpdOU7zPKIKRJleRpwKnAT4AH0szeeVKS7ToNTLdL8u1pyo8edSxSLyfHkSSNvSRTU9Cv1vN8yvbA5SMOSZpUnwb2raofASR5FPAfwCnAxl0Gpts9dpryx4wyCKmfiaMkaRJMtSiuwR1bFwu4FNhv5BFJk+mBwC5JPg9sWlXPSPJd4MaO45r1khzUPl2j5/mU7WnWdJQ6Y+IoSRp7VfVYgCTvqqq3dR2PNMFeDLwB+BzwvLbseuBZwPu7CUmtrdqvq/Q8h+YG2fnAO0YdkNTLyXEkSRMnyabAur1lVfW3jsKRJkaSs4DHVdU5Sa6qqg2TrApcVlV2VR0DSV5RVZ/tOg6pny2OkqSJkeRJwGHA5n2bCnAdR2np1qNpvYLm9wZgdeCmbsJRv6r6bJL1aSYu6r9BdkI3UUkmjpKkyfJJ4J3A4VV1fdfBSBPoRODfgYN7yl5HM8uqxkCSlwKfABYC1/VsKpqxjlIn7KoqSZoYSa4ENnbNOenOSbI5cBywCbAF8DfgWuDpVXVJl7GpkeRC4B+q6rtdxyL1MnGUJE2MJB8ATq+qw7qORZpUSQI8DNiGptvqb6rqtm6j0pQklwL3qKpbu45F6mXiKEmaGElOAnalmZb+Dq0jVbVHJ0FJ0nKUZH+asajvNKHXODFxlCRNjCTTrtdYVYePMhZJWhGSnA/cnWbCoit6t1XV1p0EJWHiKEmSJI2NJI+ebltV/WyUsUi9TBwlSROjHZv1D8CLgE2q6oFJ9gDuXlVf7zY6SZJWXqt0HYAkScvgIODlwKHAVJetC4B/6ywiSVqOkqyZ5OAkf0uyoC17YpJ/6jo2zW62OEqSJkY79ufBVXV5kquqasO2FfLKqtqw6/gk6a5K8kmapVLeC3y3qjZIsgXwg6raqdvoNJut1nUAkiQtg1VpFsWGZjFsgHV7yiRp0j0b2KGqFiW5DaCqLmyTR6kzdlWVJE2S/wEOSbIm3D7m8Z00C5pL0srgJvoad5LMpW+GVWnUTBwlSZNkf2BzYAGwPk1L4zY4xlHSyuO/gcOTbAeQZHPg48BXO41Ks55jHCVJEyfJZjST45xfVZd0HY8kLS9J1gDeB7wCuBtwHfBZ4N+q6qYuY9PsZuIoSRprSVLtP6sk0/aUqarbRheVJK14bRfVy8sLdo0BE0dJ0lhLck1VzWmf38biSXFurwJUVa068uAkaTlIsm1VndM+3366elX1t5EFJfVxVlVJ0rjrnX5+u86ikKQV50/Aeu3zM2lukKWvTtHMLC11whZHSZIkSdJQtjhKksZakiNZsnvqEqpq3xGEI0nSrGTiKEkad2f2PN8E2I9m3cZzaWZWfQZweAdxSdJykeQkZnaDbI8RhCMNZOIoSRprVXXg1PMk3weeVlUn9ZQ9Cjigi9gkaTn5XM/zewJ/T3NDbOoG2X7AYR3EJd3OMY6SpImRZAGwSVXd3FO2OnDF1MyrkjTJkvwKeHlVzespux9wWFU9orvINNtNux6WJElj6PfAu5OsDdB+PRj4Q5dBSdJydF/grL6ys4H7dBCLdDsTR0nSJHkpsBuwIMmlwALgUYAT40haWfwM+GKSeyVZO8mOwOeBk5byOmmFsquqJGniJNka2By4uKrO6zoeSVpekmwEfBJ4Ds26jbcARwP/XFWXdxmbZjcTR0nSREoSehbIrqrbOgxHkparJKsAc4H5/n3TOLCrqiRpYiS5R5JjklxBcxf+5p6HJK1M1gHuBmybZPsk23cdkGY3E0dJ0iT5DHAT8DhgIfAQ4Fjg1V0GJUnLS5L7Jfk9zRjuM9vHX9uH1Bm7qkqSJkbb0rh1VS1KcnVVbdCOB/pFVTnjoKSJl+SnwP8CB9HMprot8B6av3Nf6i4yzXYmjpKkiZHkMmCrqroxyTnAw4BrgMurar1Og5Ok5SDJVcCmVXVzzw2ydYA/V9V2Xcen2cuuqpKkSfJr4Knt8+8DX6OZbfCUziKSpOXrBmD19vnl7SzSqwAbdxeSZOIoSZos+9CscQbwBuAE4M/A3l0FJEnL2UnA89vn3wC+S/N374TOIpKwq6okaUIkWRU4DHhlVd3YdTyStKK1S3LsDawHHFFVizoOSbOYiaMkaWIkuZhmchyX35C00mlvkP0YeJI3yDRu7KoqSZokHwYOTLL6UmtK0oSpqluB7fAaXWPIFkdJ0sRIcj5wd+BWYD5QQICqqq27jE2Slockfw/sAbwduIDm7xwAVXVbV3FJJo6SpImR5NHTbauqn023TZImRZKp5LD3In3qBtmqHYQkAbBa1wFIkrQMHjdN+Y1JtgW+V1WXjjAeSVreXKtRY8kWR0nSxEjyVeDZwG+A84GtgF2B44AtgQcAz62q73UWpCRJKyFbHCVJk2QV4IVVdcxUQZK9gL2r6hFJ9gPeC5g4SppISY7kjt1Up9xIM+bxW1V16mijkpyxSZI0WZ4EHNtX9h3gKe3zLwHbjzQiSVq+FgB70YxrvKD9+kyaScHuC/wyyb7dhafZyhZHSdIkOQt4DfDxnrJXt+UAmwDXjTooSVqOdgSeWlU/nypI8nfAQVX1hCRPBj4CHNFRfJqlHOMoSZoYSR4CHA2sClwIbEFzF/45VfW/SfYA7l1Vn+0wTEm605IsADauqlt6ylYHLq+q9ZMEuLaq1u0sSM1KJo6SpInSXkA9ArgHcDHwy6q6uduoJGn5SPIz4FfA26vqhiRrAe8AHllVeyTZHvipa9dq1EwcJUmSpDGRZDvgy8AuwJXARsApwEuq6m9JdgHuXlXf6TBMzUImjpIkSdKYSbIVbc+Kqjqv63gkE0dJkiRpTCT5fVU9eED5KVW1SxcxSeByHJIkSdI42aG/oJ0Qx6WG1CmX45AkSZI6lmRqeY01ep5P2RaYN9qIpDsycZQkSZK6d9Y0zwv4OfDfow1HuiPHOEqSJEljIsmTqur7Xcch9XOMoyRJkjQ+bmqX5CDJ3ZMcnuQLSe7edWCa3UwcJUmSpPHxSeDW9vkhwOrAbcChnUUkYVdVSZIkaWwkuaaq5iRZDbgU2Aa4CbioqjbpNjrNZk6OI0mSJI2Pa5JsBtwfOK2qFiZZg6blUeqMiaMkSZI0Pv4L+C2wBvCGtmw34C9dBSSBXVUlSZKksZJkR+DWqjqr5/s1q+pP3Uam2czEUZIkSZI0lF1VJUmSpA4lOb2q7ts+Px8Y2LJTVVuPNDCph4mjJEmS1K1X9Dx/SWdRSEPYVVWSJEkaE+0Mqi8FdgbW7d1WVft2EJIE2OIoSZIkjZPDgQcBx9Gs4yiNBVscJUmSpDGR5Cpgu6q6uutYpF6rdB2AJEmSpNudB6zZdRBSP1scJUmSpA4l2bPn2wcD/w/4KH1dVavqhFHGJfUycZQkSZI6lOTsGVSrqtp+hQcjTcPEUZIkSZI0lGMcJUmSJElDmThKkiRJkoYycZQkSZIkDWXiKEmSJEkaysRRkiRJkjTU/wdnxq05lu6qgAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-15 03:57:32,897 - matplotlib.legend - WARNING - No handles with labels found to put in legend.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3sAAAJwCAYAAAAwfXiUAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABbH0lEQVR4nO3dd5hkZZn38e+PmQEkpwEByYhgDoi6rmDAgAHXsGYBE4Z1XXR39TWDinlNi4ggKmBERQUUIxJ0TRhQEUSRLOCQhhycud8/zumZmqZ7uoeZrtN9+vu5rrq66jmnTt3dp6r6uc+TUlVIkiRJkvplta4DkCRJkiSteiZ7kiRJktRDJnuSJEmS1EMme5IkSZLUQyZ7kiRJktRDJnuSJEmS1EMme5I6lWS/JJXkkXfy+Y9sn7/fKg1sFkhyYPu323Y2vv5skuRRSX6W5Ho/L9PPWJ+FFf1uTHJBklOmKL5TklwwFceWNLVM9qRZbCBRqiSHjLPPpklua/c5ZcghSuNKskFbSX5k17FMZ0k2BI4D1gb+E3ghcFqnQWnaSXKAFwGk/pnbdQCSpoVbgOcl+c+qunXUthcCAf4x/LCk5doAeHt7/5Tuwpj2Hkzzt3pJVR3XcSyavGOALwG3Den1DgAuAD47xrbH0fwfkDTD2LInCeDrwIbAU8fY9iLg28DoJFDSBJKse2e2rarXaN21/Xn1qni9gdedk2StVXnMgWMnyTpTceyZoqoWVdUtVbV4GsRy2xgXAiXNACZ7kgB+DfyOJrFbIsluwL2Az4z3xCT/kuQnSW5MckN7f6ykkSQvS3JOkluT/CXJAYxztTjJ+kne1+53a5IFSb6YZPs7+0sOjIu5Z5KPJLksyU1JfpjkHu0+T0/y6yQ3t2Ng9h/nWHsm+V6Sa5PckuR3SV4xxn6PS/LlJH9tj3lt+7w9xtj3lPY1t2h/12va+L6bZKdJ/o47Jzk0yVnt+KybkvwqyUuX87S1k3wsyeVtjD9P8pgxjv2kJKcmubLd76Ikx42OLcl9k3w9yVXt3+aPSV6fZM4k4v9skhpnWyX5bHv/kcD57aa3D3RHvmDUc56d5McDf4ufJ3nmRHEMPD9JXtn+DW9q3+M/SvKoUftt277+ge1r/irJzcD/Dsae5DFtPDcAJww8f1Kfo/b9cUqSB7Tvi4U0n93x4r8AOKp9+KORv9PA9k2SfDzJxWm6a1/cPt541HFGxo/tmeStSc6j6RHwrEn8DZ/Rxnxt+zf8U/t+W73dvmTcbZJ/S/LH9tj/1W6fm+QN7fvolvZ99fUk9xnjtfZJ8ov2tW5sP3efTzJ/YJ97JflKkkvTfLdc3p7TJ03we+zVxvmacbb/NM331Lz28W7tOT+3/b2vb8/r0yb6m7XPH3PMXpKtkhybZGGS65KckGSHcY7x7CTHp/ms3prms/uNJPcdtV8B2wB7DHyWlowhzDhj9pLsnuT7bSw3p/nufMkY+630d5ukO8dunJJGfBr4UJItq+rStuzFwN+BE8d6QpJXAR8HzgHe0RbvB3wjycur6vCBfQ8APgycCbwJWIumMvf3MY67PvB/wNZtXGcBmwOvAn6eZNequnAlftejgBuAdwPzacYxfTfJW4H3A59oX/clwCeT/LGqfjwQ3/7AYcDPgIOBG4HHAp9IskNV/ffAa+0HbAQcDVwCbAm8FPhhkkdV1emjYlubZjzVz2j+TtsB/wF8M8m9q2rRBL/bI4Hdac7Z+e3x/hU4Isn8qnrPGM85GlgEvA9YF3g58J0ke1XVD9rfeQ/geOAPwHuAa4EtgD2BHYFz2/12BU4Fbqd5b1wOPKU99v2A508Q/2SdDbyW5j31dZoxadCcV9pY3gW8GfgO8FZgMfA04CtJXl1VH5/E6xwDPBf4Ks1FjzXa3+H7SZ5eVceP2v9fgNfQvIcOA64b2LYr8AzgCJYmYCv0OWptDZwMfAX4GrC8FrADgL2A/Wne72cPvO7I52xHmvf7r4EHAK8EHp1kt6q6ftTxPgjMa3+H64A/Lee1SXIwzfv4jzTn6jJgh/bv8DaW7aJ4ALBxe+zLgYvb8s/TJJXfp/m73hX4N+CnSR5RVb9pX+uFNH/X09tj3wxsBTwR2BRY0CaxJ7fHPQy4ENiE5tw8BPjWcn6d77Vx7QN8bNTveXfgocDHqur2tvhpwM7Ase3rbAzsCxyX5PlV9YXlvNaYkmxA8/2wVRv/H4E9gB8BdxnjKa8GrgIOb2Pfgea98JMkD6yqP7f7vZDm/FxJ8502YsFyYnkKzWfvcuB/gOuB5wCfSrJ9Vb151FNW9rtN0p1RVd68eZulN5rEoGiSro1pumq+qd12F5oK/QfbxzcApww8d8O27C/AegPl6wHn0fzj36At24AmIfojsNbAvndrj1HAIwfKP0pTUbvfqHi3oalgfnaM32G/Sfy+B7b7ngBkoPw1bfl1wFYD5fNpWhi+OFC2eVv2hTGO/1GapGn7gbK1x9hvM5pK1bdHlZ/SxvH6UeX/3ZY/fhK/41ivt1p77IXAvDH+Hj8HVh/jvJw9UPahdt9NJ3j9n9CM77zvQFloKrwFPGaM1992oOyzzb+mMY9do879tm3ZgWPs+8B227vH2PaN9lyvO8Hv8rT2GPuPKp8LnEGTTGdULLcDu4wTewF7jiqf9OeoLb+gPc5LV+Bzvh+jPmNt+cFt+atGlf9bW/7OMY7xJwY+wxO87m7tc04G1hy1LQN/u0e2+109+v1FcxGlgC+z7Gf2fu377PSBsuPa8zp3OTHt3R7vWZP9+416/gfa599zVPk72/IHTvBZXKv9G/5xVPlYn4U7nDeahL2AF416/kfa8lNGlY8Vwy403/WHjiq/YPTzB7adAlww8HgOTQJ7LbDFQPnqNN8Bi4C7j3r+Sn23efPm7c7d7MYpCYCquoqm5Wa/tujpwPo0V/zH8liaK7Ufq6olrRft/Y/RtDbs2RY/jqaS8/Gqumlg30tortovkSQ0LSenAZem6Wa2SZJNaBLGn7XHWxkfq6oaeDzSunZ8VY20JlBVC2gqZncf2PeZNK07Rw7G1sZ3Ak1itefAMW4c+N3WaVsWFtEkWA8ZI7bFjGo1YGlLxN2ZwKjXW7N9vY1oWiXWo2lpGO3DVbWkhWXgvOycZJe2eGH78xlJxuwVkmRT4J9o/o5Luha2f+uR1oJJdWFbBZ5PU4k8aozzdDxNC+bDJjjGC2iSrW+Mev4GNOd6W+54Tr5VVWcztjOrbSkdsCKfoxFXs5yu1SvgaTQtN6NbDj/Zlo91rj4x+BmewEgr7hur6pbBDdUatf/RVTW6pX8khoMH96+qM2nOwT8PdNFcSPM986T2e2QsI+/jvZKsN8nfY9BIi+w+IwXta70A+ENV/XogxsHP4lrtZ3Etms/zLnfy9f8FuIKmNX7Q+8baeSSGNNZr378j32tjff9M1oNoe15U1d8GXu82mt4Rq3HHMeAr9d0m6c6xG6ekQZ8BvpXkn2m6cP6iqv44zr7btT/PGmPbSNn2o36eM8a+o48/n6aV8XGM34VoZScs+Ouox9e0P88fY99raFoUR4wkP6Mr7YM2G7nTjqU5GHg8TZIwaHRlF+BvoyvGNN2woPm7LFeaSS0OpOn2ttUYu2w4RtlYycnIedm+3X4ITeXtUOB9SX5M0z3yi21SDMt/T5xNc97u9JjLFbQLTevRWO+5EZstZ9vIMdalqVwv7xjnDjw+d7wdx9m2Ip+jEefVqunyth1wRlUtM9NuVf0jybk0raOjLe/3G+3uNO/xMye5/3h/n8WM/R49iyb52Y7mu+LdNF2YvwFcleRU4CTgy9V2R62qU5McTXNR6/lJfknzWf7yyHddmrGl81nWzVW1sKr+kOTX7XPfVM3kKbvTJP6vH3xCe/HjXTSfm03HiH8Dlu3mOxnbA78cff6r6rIk147eOckDaFodH0lzUWHQWN93k3Vn3rcr9d0m6c4x2ZM06LvApTTT2T+KZuzOsI1ckf8B41ytXgXGqyiPV54x7u9DM/5oLH+FJYnXaTSVrI8Av6dpKVoMvBF49ArEMDqO8XwBeDJNa81pNJWpRTTjll7LnZyYq6quSvJg4BE0rVG704zxOSjJE6vqp3fmuGO91FiF47UmLkfaY+3F+H/TsSqqo4+xAHjecvb5w6jHy2v1mmyL2ERW1XGG8doj3Ven4tjLvlDVn5PcE3hMe9uDZvzfQUl2r6rz2v32TfIBmvfGI2jG7L45yQFVdQjNRZLRidBRLO31cDTN5/nRNN9T+9C8xz43snPb2vc9mgsGH6Xp9ruw3e9FNO+pKe1dlWRrmu+A62gSvj/R9I6oNv5hz3a6st9tku4Ekz1JS1TVovaq9xtpxsx9cTm7j7SO3Qv44aht9xy1z8jPnZez74gFNONA1hujy9t0MDKhwZWTiO8xNJOYvLiqlul2104eskq1kzc8GTimql4xatvoroCDduGOrS+jzyFta8Ip7Y00M/r9CngL8CSWVpDvNcZr7ExTuR3dqjra1e2xN6qqwaUCxmoRXF4S8WfgCcBFy+lWOZE/AzsBP6uqGyba+U5akc/RVLz2PZLMHWzdaxPrnVbB655Lk1DdD/jFSsS4Gs17dPSsoyN/nyWJWTXLA3y7vZHkiTSTrryOZiziyH5/oEnUP9B+bn4OvDfJyKRCjx31Wn8buP8FmrF7+yT5CU3X7u9X1eDFn/vS/N7vqKq3Dx4oy58ZdyJ/Be6eZM5g616Szbljz4Gn0SR0e1fVj0bFMDJGe9Bkk/KROGDsz/pUv28lrQDH7Eka7TDgIOAVg2OIxvB9mqvE/56Bdb7a+/9OM+nE9wf2vRn4twysy5XkboxqNWm7RX0e2C3jTJHfdo/qyrE0laSDktxh9rs0S0as0T4cqYxl1D6PY+XGy4xnvNfbnGYG0PG8Nu00+O3+I+flTyOJUjvWZ7RzaM7rRgDteKv/A56S5N4DxwvNBQRoZu9bnpGufKOT0/8cY9+RBGyjMbYd0/58d8ZY8iHJRF04oWnBWY1m9tE7mOQxJrIin6NV7Rs03RVHvzde1pZPdK4mMjLb5LsH318jljOubtA32p9vHNy/fX/tDfx4pBvxOO/RkTF0G7X7bJRkmbpPVV1LkzCuRTORzC1V9YNRtz8O7L+Apnvo02nGJa7HwOyqrfE+i/dm5catfpOm6/A+o8rfMMa+48XwMpauvTjoBsb+LI3l18BFwIuSLDlWmmUnRiZd+eYkjyVpCtmyJ2kZVXURzZivifa7NsnraaaM/3na9c9oujrtCLy8qha2+16TZlmDDwL/17YergW8gqb15AGjDv9m4OHAsUmOpZmU5TaasXNPpGlN2u9O/5IroaouSfJK4FPA2UmOoZmVbj5wH5oxRPekmdnux7TTkqdZr+oS4P4005z/vt1/VcZ2fZLvAS9Is8bbL2n+Zi+nqcyONy5mLnB6ki/SjFF7Bc1srIPriR3RJoHfo/l97wI8u91/cLKI/6BZeuH0gVaSJ9OMWfxCVY1uvRrtizRjrw5PsjNNS98TaKbHH/37XpXkL8Bz0qz7dgVwY1WdUFW/THIgzXv5t0m+QtM6sznN5BJPpJk5cFxV9dUknwFeneSBNMtZXEkzW+nDaN7nKzUGcUU+R1Pg/TTLcny8/f1+Q/NZfAlNl7/3r8zBq+oXSd5Hk4j8OsmXad4P29G0hu1G04q/vGN8v/0OeA6wYZITWbr0wi0s+x79Xjtu7XSaZRs2YOmMliPJ/z40Fze+TjMD6u003T0fDxxbVTdP8tc7iibZ/B+a7pnfGLX9bJpuwq9vL3D9iaa19OU0n/0HTfJ1Rns/zYWYI5I8qH2NR9K8H68cte9JNF1jj0lyCM3444fTvPfP4451wJ8BL0nyTpaOsT1hcKKZEW0vkFfTXBD4ZZLDabqoP5tmCYp319JlHSR1aSqm+PTmzdvMuDGw9MIk9l1m6YWB8qfRtObc2N7+D/iXcY7xcppKz600Fa0DaMavjDUt/Fo0a6P9nqb16HqaCsgRwEPG+B32m8TvcCCjpjdvy7dl/Cn8T2FgyvGB8ofTVHT+TpOI/o1mrav/ZGCaeZruXN+hqWhd3x7vEYyxxMByXmvc+MbYdxOaRPRvNJXh39O01Ow3+u888Pe4F83i35e3z/kF8NhRx306zSyWl7TnbwFNUveMMWK4H03l9+p237NpJq+YM8nz8RCa6dtvoanAHk5TcS8Gll5o992t3XdkLNIFo7Y/iWYs6kgsF9NUgl+xAp+TF9IkENe1MV1AM83/syd7jsaK/c58jljO9PjLOfYdzv3Atvk0k+5cQpP4XEKTeG4y2WNM4vWf256j69vf7RyaMWOrT+YzTJOUvKF9H93anstvAPcZtd/LaFpBL6f5TF5G053zUQP73J8mUftLG8t1NF2Y/xNYYwV+p9VpxsMWcMQ4+2xDsxbiApqk6xfteb7D+36csjH/5jSzYH61jf06mllJdxjrvUEztvbH7d/+WpourfdmjO8amklkvtb+fRcPxjPW/m35Hu3ffOSz8RvgJWPsN97zt2WS323evHm7c7eRNW4kSZIkST3imD1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6qGhJntJPpfksiTXJTk3yUsHtq2V5NAkVyZZmOS0YcYmSZIkSX0yd8iv9x7gJVV1a5KdgVOS/KaqfgUc3sazC3A1cP/JHHCTTTapbbfddorClSRJkqTp7Ve/+tWVVTV/dPlQk72qOmvwYXvbIcmNwN7A3arqunb7ryZzzG233ZYzzjhj1QYqSZIkSTNEkgvHKh/6mL22q+ZNwDnAZcC3gd2AC4GD2m6cv0/yjGHHJkmSJEl9MfRkr6peBawLPAI4DrgVuBtwb2AhsAXwauCoJLuMdYwk+yc5I8kZCxYsGE7gkiRJkjSDdDIbZ1Utqqof0yR5rwRuBm4H3lVVt1XVqcCPgMeN8/zDq2rXqtp1/vw7dE2VJEmSpFmv66UX5gI7AL8bY1sNORZJkiRJ6o2hJXtJNk3ynCTrJJmT5PHAc4EfAqcBFwFvTDI3ycOBRwHfHVZ8kiRJktQnw5yNs2i6bB5Gk2ReCBxQVccDJHkq8Cng/7Xb9qmqc4YYnyRJkiQNxeLFi7nyyiu59tprWbRo0bj7zZkzhw022IBNNtmE1VZbsba6oSV7VbUA2GM5288CHjaseCRJkiSpK5dccglJ2HbbbZk3bx5J7rBPVXH77bdzxRVXcMkll7D11luv0Gt0PWZPkiRJkmadG2+8kS233JLVV199zEQPIAmrr746W265JTfeeOMKv4bJniRJkiR1YLLdMle0++aS592pZ0mSJEmSpjWTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqQFWt0v1GM9mTJEmSpCGbN28eN99886T2vfnmm5k3b94Kv4bJniRJkiQN2aabbsqll17KTTfdNG7LXVVx0003cemll7Lpppuu8GvMXdkgJUmSJEkrZr311gPgb3/7G7fffvu4+82bN4/NNttsyf4rwmRPkiRJkjqw3nrr3akkbrLsxilJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9NLfrAIblQf99dNch9MqvPrBP1yFIkiRJWg5b9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHhprsJflcksuSXJfk3CQvHWOftyWpJHsOMzZJkiRJ6pNht+y9B9i2qtYD9gbeleRBIxuT7AD8K3DZkOOSJEmSpF4ZarJXVWdV1a0jD9vbDgO7fBx4A3DbMOOSJEmSpL4Z+pi9JIcmuQk4h6YF79tt+b8Ct1bVt4cdkyRJkiT1zdCTvap6FbAu8AjgOODWJOsC7wb+YzLHSLJ/kjOSnLFgwYKpC1aSJEmSZqhOZuOsqkVV9WPgbsArgQOBY6rqgkk+//Cq2rWqdp0/f/7UBSpJkiRJM1TXSy/MpRmz9xjgNUkuT3I5sBVwbJI3dBqdJEmSJM1Qc4f1Qkk2BR4NnAjcDOwJPLe9vQOYN7D7L4HXAScNKz5JkiRJ6pOhJXs0M2++EjiMpkXxQuCAqjp+9I5JFgHXVNUNQ4xPkiRJknpjaMleVS0A9pjkvttObTSSJEmS1G9dj9mTJEmSJE0Bkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqobldByCNuOgd9+k6hN7Y+m2/7zoESZIkdcyWPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqobldByBpZnj4/z686xB65Sf//pOuQ5AkST1ny54kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPXQ3K4DkCStGqfuvkfXIfTKHqed2nUIkiStlKG27CX5XJLLklyX5NwkL23LH5rk+0muTrIgyVeSbD7M2CRJkiSpT4bdjfM9wLZVtR6wN/CuJA8CNgQOB7YFtgGuBz4z5NgkSZIkqTeG2o2zqs4afNjedqiqYwf3S3IIYP8ZSZIkSbqThj5BS5JDk9wEnANcBnx7jN12B84ao1ySJEmSNAlDT/aq6lXAusAjgOOAWwe3J7kv8Dbgv8c7RpL9k5yR5IwFCxZMZbiSJEmSNCN1MhtnVS0CfpzkBcArgY8BJNkROAn4j6o6fTnPP5xmjB+77rprTX3EkiStvEP+84SuQ+iNV//PU7oOQZKmva7X2ZsL7ACQZBvgB8A7q+qYTqOSJEmSpBluaMlekk2TPCfJOknmJHk88Fzgh0m2BE4GDqmqw4YVkyRJkiT11TBb9oqmy+YlwDXAB4EDqup44KXA9sCBSW4YuQ0xNkmSJEnqlaGN2auqBcAe42w7CDhoWLFIkiRJUt91PWZPkiRJkjQFTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYdM9iRJkiSph0z2JEmSJKmHTPYkSZIkqYeGmuwl+VySy5Jcl+TcJC8d2PaYJOckuSnJj5JsM8zYJEmSJKlPht2y9x5g26paD9gbeFeSByXZBDgOeCuwEXAG8OUhxyZJkiRJvTF3mC9WVWcNPmxvOwAPAs6qqq8AJDkQuDLJzlV1zjBjlCRJkqQ+GPqYvSSHJrkJOAe4DPg2cC/gzJF9qupG4Ly2fKxj7J/kjCRnLFiwYAhRS5IkSdLMMvRkr6peBawLPIKm6+atwDrAwlG7Lmz3G+sYh1fVrlW16/z586cyXEmSJEmakTqZjbOqFlXVj4G7Aa8EbgDWG7XbesD1w45NkiRJkvqg66UX5tKM2TsLuN9IYZK1B8olSZIkSStoaMlekk2TPCfJOknmJHk88Fzgh8DXgXsneUaSNYG3Ab9zchZJkiRJunOG2bJXNF02LwGuAT4IHFBVx1fVAuAZwMHttocAzxlibJIkSZLUK0NbeqFN6PZYzvYfADsPKx5JkiRJ6rOux+xJkiRJkqaAyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT10NyuA5AkSZoODn7BM7sOoVfe/LmvrvJjnn3wyav8mLPVLm9+9Co/5oEHHrjKjzmbrYq/56Ra9pK8O8laA4+fmOQuA4/XS3L0SkcjSZIkSVolJtuN8w3AOgOPvwRsPvD4LsDzV1VQkiRJkqSVM9lkLxM8liRJkiRNI07QIkmSJEk9ZLInSZIkST20IrNxviLJDQPPe0mSq9rH667asCRJkiRJK2Oyyd5FwIsGHl8OPG+MfSRJkiRJ08Ckkr2q2naK45AkSZIkrUKrZMxekrWTvHRVHEuSJEmStPJWKtlL8rAkn6Lp1vmRCfZdI8mRSS5Mcn2S3ybZa2D7s5Kc3W77Y5J/WZnYJEmSJGk2W+FkL8nGSV6X5I/Aj4FNgZe0P5dnLnAxsAewPvAW4Ngk2ybZEvgc8DpgPeC/gS8kmeiYkiRJkqQxTDrZS/L4JF8BLgH2Bj4ELAb+X1UdW1U3Le/5VXVjVR1YVRdU1eKqOhE4H3gQcDfg2qo6qRrfAm4EdriTv5ckSZIkzWqTSvaSXAB8FPgtsEtVPbKqPrUyL5xkM2An4CzgDODsJHsnmdN24bwV+N04z90/yRlJzliwYMHKhCFJkiRJvTTZlr27AmfSJHsXr+yLJpkHfB44qqrOqapFwNHAF2iSvC8AL6+qG8d6flUdXlW7VtWu8+fPX9lwJEmSJKl3JpvsbU3T+vZB4G9JPprkwUCt6AsmWQ04BrgNeHVbtifwfuCRwOo04/o+leT+K3p8SZIkSdIkk72q+ntVfaCqdgGeSTOJyo9oJl15eZJ7TeY4SQIcCWwGPKOqbm833R84rarOaMfz/RL4ObDnCv02kiRJkiTgTszGWVWnV9WLgC2AVwEPA36f5OxJPP0TwC7AU6rq5oHyXwKPGGnJS/IA4BGMM2ZPkiRJkrR8c+/sE6vqOuAw4LAk9wGWu6h6km2Al9OMybu8aeQDmrF5n09yIPDVduKWBcC7q+p7dzY+SZIkSZrNJpXsJTl+ZV+oqi4EspzthwCHrOzrSJIkSZIm37L3ZOBC4JSpC0WSJEmStKpMNtn7APBCYHfgM8Bnq+qSKYtKkiRJkrRSJjsb5xuArYDXArsCf05yUpJntmvmSZIkSZKmkUnPxllVi6rq+Kr6F2A7mqUX3gVcmmSdKYpPkiRJknQnrPDSC621gQ2AdYAbuBOLq0uSJEmSps6kk70kd0myb5LTgN8D2wD7VtX2VXXjlEUoSZIkSVphk1164QjgWcCfgSOBvavq2imMS5IkSZK0EiY7G+dLgIuAy4C9gL0GFkVfoqr2XnWhSZIkSZLurMkme0fjuDxJkiRJmjEmlexV1X5THIckSZIkaRW6s7NxSpIkSZKmMZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6iGTPUmSJEnqIZM9SZIkSeohkz1JkiRJ6qGhJXtJ1khyZJILk1yf5LdJ9hrYvlaSQ5NcmWRhktOGFZskSZIk9c3cIb/WxcAewEXAE4Fjk9ynqi4ADm/32QW4Grj/EGOTJEmSpF4ZWrJXVTcCBw4UnZjkfOBBSdYE9gbuVlXXtdt/NazYJEmSJKlvOhuzl2QzYCfgLGA34ELgoLYb5++TPKOr2CRJkiRppusk2UsyD/g8cFRVnQPcDbg3sBDYAng1cFSSXcZ5/v5JzkhyxoIFC4YVtiRJkiTNGENP9pKsBhwD3EaT1AHcDNwOvKuqbquqU4EfAY8b6xhVdXhV7VpVu86fP38YYUuSJEnSjDLMCVpIEuBIYDPgiVV1e7vpd2PsXkMLTJIkSZJ6Ztgte5+gmW3zKVV180D5aTQzdL4xydwkDwceBXx3yPFJkiRJUi8Mc529bYCX0yypcHmSG9rb89sWvqfSLMewEDgC2KcdzydJkiRJWkHDXHrhQiDL2X4W8LBhxSNJkiRJfdbZ0guSJEmSpKljsidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk9ZLInSZIkST00tGQvyRpJjkxyYZLrk/w2yV5j7Pe2JJVkz2HFJkmSJEl9M8yWvbnAxcAewPrAW4Bjk2w7skOSHYB/BS4bYlySJEmS1DtDS/aq6saqOrCqLqiqxVV1InA+8KCB3T4OvAG4bVhxSZIkSVIfdTZmL8lmwE7AWe3jfwVurapvdxWTJEmSJPXF3C5eNMk84PPAUVV1TpJ1gXcDj53k8/cH9gfYeuutpyxOSZIkSZqpht6yl2Q14BiarpqvbosPBI6pqgsmc4yqOryqdq2qXefPnz8lcUqSJEnSTDbUZC9JgCOBzYBnVNXt7abHAK9JcnmSy4GtaCZvecMw45MkSZKkvhh2N85PALsAe1bVzQPljwHmDTz+JfA64KQhxiZJkiRJvTG0ZC/JNsDLgVuBy5tGPgBeXlWfH7XvIuCaqrphWPFJkiRJUp8MLdmrqguBTLhjs++2UxuNJEmSJPVbZ0svSJIkSZKmjsmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT1kMmeJEmSJPWQyZ4kSZIk9ZDJniRJkiT10NCSvSRrJDkyyYVJrk/y2yR7tdsemuT7Sa5OsiDJV5JsPqzYJEmSJKlvhtmyNxe4GNgDWB94C3Bskm2BDYHDgW2BbYDrgc8MMTZJkiRJ6pW5w3qhqroROHCg6MQk5wMPqqqvDe6b5BDg1GHFJkmSJEl909mYvSSbATsBZ42xefdxyiVJkiRJkzC0lr1BSeYBnweOqqpzRm27L/A24KnLef7+wP4AW2+99RRGKkmSJEkz09Bb9pKsBhwD3Aa8etS2HYGTgP+oqtPHO0ZVHV5Vu1bVrvPnz5/SeCVJkiRpJhpqy16SAEcCmwFPrKrbB7ZtA/wAeGdVHTPMuCRJkiSpb4bdjfMTwC7AnlV180hhki2Bk4FDquqwIcckSZIkSb0ztGSvbbl7OXArcHnTyAdt2Y7A9sCBSQ4c2VBV6wwrPkmSJEnqk2EuvXAhkOXsctCwYpEkSZKkvuts6QVJkiRJ0tQx2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHjLZkyRJkqQeMtmTJEmSpB4y2ZMkSZKkHhpaspdkjSRHJrkwyfVJfptkr4Htj0lyTpKbkvwoyTbDik2SJEmS+maYLXtzgYuBPYD1gbcAxybZNskmwHHAW4GNgDOALw8xNkmSJEnqlbnDeqGquhE4cKDoxCTnAw8CNgbOqqqvACQ5ELgyyc5Vdc6wYpQkSZKkvkhVdfPCyWbAhcD9gVcCq1fVKwe2/wF4e1V9bYzn7g/s3z68B/CnKQ94eDYBruw6CC2X52h68/xMf56j6c3zM/15jqY/z9H01sfzs01VzR9dOLSWvUFJ5gGfB46qqnOSrAMsGLXbQmDdsZ5fVYcDh09tlN1IckZV7dp1HBqf52h68/xMf56j6c3zM/15jqY/z9H0NpvOz9Bn40yyGnAMcBvw6rb4BmC9UbuuB1w/xNAkSZIkqTeGmuwlCXAksBnwjKq6vd10FnC/gf3WBnZoyyVJkiRJK2jYLXufAHYBnlJVNw+Ufx24d5JnJFkTeBvwu1k6OUsvu6f2jOdoevP8TH+eo+nN8zP9eY6mP8/R9DZrzs/QJmhp1827ALgV+MfAppdX1eeT7AkcAmwD/BzYr6ouGEpwkiRJktQznc3GKUmSJEmaOkOfoEWSJEmSNPVM9iRJkiSph0z2pOVIMifJeUnW6DoWaSZqP0NH+Rmavtpz9A7P0fTVLlsl6U6Y7XU5vzyk5aiqRcAiYM2uY9HY2i/xU2brl/h0136GHgcs7joWja09R68Cbp9oXw1fkjnAjX7HTV/+H5reZntdzmRvmkgyL8kjkjy7fbx2u96guvcR4NgkeyTZIcn2I7euA9OSL/Ht8PtsOvswcFCSeV0HonEdDbyi6yB0R+133LnAxl3HorH5f2hG+AiztC7nbJzTQJL7AMfTLEtxt6paJ8kTgX2r6tndRqck47VIVFXNGWowGlOSFwO7A28HLgGWfLFVlS1KHUtyMXBXmiurC1j2/GzdVVxaKsmPgYcAlwIXs+w52r2ruNRI8nrgOcBHueN33MldxaWl/D80vc3mupzJ3jTQ/pP9ZFUdk+SaqtqwbdU7t6q27Do+abob+BIf/EILs+BLfCZIssd426rq1GHGorEl2Xe8bVV11DBj0R0lOX+cTVVVvW+ZmAn8P6TpymRvGkhyDbBRVVWSq6tqo7Z8yX11L8nWwJbAJVV1cdfxaKkk24y3raouHGYs0kyUZE7bFU3SneD/oZlhNtbl7Fs8PVwAPGiwIMluwF86iUbLSLJ5klNpzsdxwHlJTkuyRcehaakNq+rCsW5dB6YlY5IPSvLXJLe0Pw9KsnrXsWmJy5McmuThXQeisSWZm2T3JM9tx/jP7TomLTXwP+di4DbgYv8PTR+zuS5nsjc9vBX4VpKDgNWTvBH4CvCWbsNS6xPAmTQJxebAhsBvgMM6jUqDvpfkrCRvmQ2DrWeg9wN70kwAcr/256OB93UZlJbxOOAG4ItJzk/ynnY8uaaBJDsDZwNfAF4DfBE4J8kunQamJZKsl+Ro4Baasa83t8vOrN9xaGrM2rqc3TiniSQPAF4GbENzVeiIqvpVt1EJIMmVwOZVdftA2RrApVW1SXeRaUQ7NfkTgOcCewNn0VSKvlxVf+8yNkGSS4D7VdVVA2WbAGc6Lnn6acdYPhd4BnBZVd2345BmvSQnAycBH6y24pbkv4AnVdWjOg1OACT5LLAu8EbgQpr63MHATVU17phYDcdsrsuZ7EkTSPJn4JlVdeZA2X2B46pqx+4i01iS3AV4KvBK4KFV5bpHHUtyKXDfMZK931VV77vQzDRJNqOZ+XEf4O5VtV7HIc16Sa4G5g+Oq2y7cS6oqg27i0wjklwObF9VNw2UrQOcV1WbdReZYHbX5ezvPQ0kecc4m26lmb73O1V1xRBD0rLeD/wgyZEsvVr3Iprut5pGkqwJPBl4NrArcHq3Ean1FeCEtqv6RTSfobcAx3YalZZIsgFNS97zgIcC36PpZnt8h2Fpqb8BewCDyyw8oi3X9HALMJ+mnjBiE5q6nLo3a+tytuxNA0m+BDwN+AVNF86tgN2AE4C7AfcBnlFV3+ksyFkuyaNpKkFb0Pxz/WJV/bDbqDSiXZfyeTRdOP8IfAn4UlVd3mlgAqCdiOUtjPoMAe+qKitC00CSm4D/ozkvX6uqa7uNSIOS7E3TNf1EmorqtsATgRdU1Tc7DE2tJG+haQ3/EEuTidcCx1TVu7qMTY3ZWpcz2ZsGkhxL84b7+kDZU4HnVdWz2/WPXltV9+8qRmk6S/JHmkrqF6rqvK7jkWaaJM8DflZVf01yV5pWvcXAG71oMj0k2Ql4FksrqsdW1bndRqURSULTUjT6otany8q2OmSyNw0kWUizzt5gX/w5wDVVtd7g/c6CnMWSvA44uap+m+QhNF3SFtEk4z/tNjpp+kvyKOCCqjrfRGJ6SnI28PiquijJF9rim2nGie3dYWgaQzs2ebEt49LkzOa6nEsvTA/n0UwmMegVbTk0fb5vQl15LXB+e/+9NF003gV8pKuAtKwkr0ty//b+Q5Nc1E4f/7COQ1PjUJp/qtB8fubRJHuHdxaRRtuyTfTmAo8H9qf5v/RP3YYlgCQfbNffJcmTgKuBa5I8pdvINKJd/3CX9v5OSU5N8qN22Qx1b9bW5WzZmwaSPJBmgcc5NGuzbElTMXp6Vf06ye7AParqiA7DnLWSXNe2sK5L0w9/flUtSnJtVW3QcXgCklwM3LuqFib5EfBN4Hpg/6p6SLfRaeAzNBe4gmYsy23A3/o+5fVM0S6P8SDg3sCBVfWIdqzlgqpynbCOJbkM2KGqbkryc5rJJhYCH64q10OcBpKcB/xTVV2R5ATgTzRrV+5eVY/uNjrN5rqcs3FOA21Cd3fgYcDmwGXAT0fWAqmq04DTOgxxtrs4yT8B9wJOa78c1mNpS4W6t36b6K1Ls2j3nu15+p+uAxMA17XT+d8b+GNV3dAmEvM6jktL/S/wS2B14IC27OHAOV0FpGWs1SZ6G9NM7/81gCTbdByXlprfJnprAv8MPBO4Hbiy27DUmrV1OZO9aaJN7Ezopqf/Br5K0xLxjLbsyTSzp2p6mLVf4jOEicQ0V1XvS/J1YNHAJEeXAi/tMCwtdW6S5wM7At+HJWtV3txpVBq0IMmONDOo/7Kqbk2yFpCO41Jj1tbl7MbZkbbb2YR//KraegjhaAUlmQdLknR1LMlewJG0X+JV9at2dsEXVtVe3UYnWDKT4JJEon28RlX9vtvIpOkvyYOBj9J8x72kqs5rk78nVNULu41OAEn2ozlHi4BnV9X32yUzXldVj+wyNo1tttTlTPY6kmSPgYcPBvYFPsbStVleDRxdVXZD61iSewJXtd0z1qG5OrQY+EBVOXFOx5KsBjwS+MngzHSz5Ut8Jmpn51xcVad2HYskrSptSx4jdYMkmwKrOetw92ZzXc5kbxpI8geaKa8vHSi7G/Cdqrp3d5EJIMmZwLOq6k9JDgPuAdwCXOkV1ekhyfVVtW7XcWhsSU4F3lRVP0nyBuB1wD+Aj1fVu7uNTpr+Ri1fsjnNbIIuXzKNJJkP3NyOSZ5Ds8D6YppF1Rd3G51mc13OZG8aSHI1sF1VLRwo2wA4v6o27CwwAc06iFW1frtg6hXAPWnGSZxfVZt2G50AknwLeGdV/azrWHRHSa4CNm3HUv4F2JtmttSf2FVdmpjrIE5/7Sypr6iq3yR5L/AUmglaflRVr+02Os3mupwTtEwPxwPHJ3kXcAmwFfDGtlzdu6Wd5fGewEVVdWU7hfyaHcelpS4ETkryTWCZ8bBV9bbOotKI1YBKsgPNRcY/AiTxYpY0OaPXQVyyfEm3YWnATsBv2/svoFmj8gbgLJo13tStWVuXM9mbHl4BHAgcBmxBs/TCscBBHcakpb4AnAysCxzSlj2QpYtzqnt3Ab7R3r9bh3FobD+m+exsDnwdoE38nJJcmhyXL5n+FgGrt5NPLWyT89WAdTqOS41ZW5ezG6c0CUkeB9xeVT9qH+8KrFdVJ3cbmTT9tWuD/SdNl6YPtBXVJwF3r6qPdBqcNAO0Y13/jXb5kqr6UjuO771V9ZBuoxNAkmOA9YCNge9W1TuT3Bv4alXt3G10gtlblzPZ60iS3dvF0kny6PH26/sbcCZJshVNVxrHhU1TbReNTRhY16iq/tpdRJK0arh8yfSWZA2amdVvp5mU5R9JHgnctaq+1GVsWmo21uVM9jqS5A8jM222a+79Y4zdqqq2H25kGi3J1sAXgfvTnJN1kjyTZn0jFxyeBtoplT8P3I9mvF7an1TVnA5DE0sqQW8Dngts3A6SfxywU1UdsvxnS4Ily8k8FNiiqr6cZG2Aqrqx28g0qO26uVlVXdZ1LFpqNtflVus6gNlqINGbA8wHdq6q7UbdTPSmh08C36Lp5z2yZtv3gcd2FpFGOxT4EbARcB2wIc1527fLoLTEh2nGGj2fpZPnnAW8srOIpBkkyX2Ac4EjgCPb4j2AT3cWlJaRZIN2ptRbgL+0ZXu3k++pe7O2LmfL3jTQrv2xV1U5q9Y01E4bP7+qFie5uqo2asuvraoNuo1OAEmuoZna//aR89Je9f5DVW3XdXyzXZLLgB2r6kY/Q9KKS/Jj4JNVdUySa6pqw/Y77tyq2rLr+ARJvgRcA7yDZhKdDdu19/6vqu7ebXSazXU5Z+OcHj4PnJjkozRLLwxOG++Yve5dAexIc1UVWNJt8KLOItJot9DMSnc7cGXbXeMamoHy6t5tjPp/01aCruomHGnGuRfwufb+SBf1G5PcpbuQNMpjaLrY3p5k5BwtSNLrNdxmkFlblzPZmx5GujIdOKq8ALtydu+DNMn4e4C5SZ4LvAl4b7dhacDpwLOAzwJfBU4CbqWZZlnd+wpwVJLXAiTZHPgI4KQF0uRcADwIOGOkIMlutN0FNS0spJkgbMlYvfbCo2P3podZW5ezG6c0CUmeCrycZiHbi2i603yj06A0pnZw/PNo+uUf7eQF3WvXA3sf8DJgLeAmmrFHb6iq27qMTZoJkjyZZqzeYTTLmBxMs0bvy6rqe13GpkaS/wfsDbyZZj3RvYB3A990iZnpYbbW5Uz2pOVoJ9D5IfD4qrq163i0fM6CNv20n6G3AwdX1a1t980ry38+0gpJ8gCaCybbABcDR1TVr7qNSiOSBHgNo5IJ4KN+33VrttflTPakCSS5kGa21Ju7jkVjS7Ih8HHgmTQLpq6dZG9gt6p6S7fRKcmVNBPoLO46FmmmaSuq5wL3nI0V1ZmgPUefBvb3HE1Ps7ku59IL0sQOAj6RZJskc5KsNnLrOjAt8Qma8RLb0EwGAvBT4NmdRaRBR9N0OZO0gqpqEbAIWLPrWDS29hw9DvCC1vQ1a+tytuxJE0gy8uU9+GEJzaKcLtg9DSRZwNJZ0AanVF5YVet3HN6s104b/xDgUpruZ4MzDu/eVVzSTJHkVcBTacaAjZ61+69dxaWlkrwe2AA40LHI089srsuZ7EkTSLLNeNuq6sJhxqKxJfkL8Iiqumwk2WtnQfteVe3cdXyzXZJxF7evqqOGGYs0Ew1UVEfrfUV1pkhyMXBXmlbYBSybkG/dVVxqzOa6nEsvSBPo+5dAT3wK+FqSNwOrJXkYzRXww7oNS2BCJ62squp9V7MeeEHXAWh8s7kuZ8ueNIEkx7Bss/+IW2m603yjqs4cblQa5Cxo01uSF4+zaeQz9DMnNZAkTZXZXJcz2ZMmkOQQ4IXA8TTjjbYCnkKzIPQGNOvqvKKqju4qRmk6S3IK8DDgCpp/qncDNqNZIHrbdrenVtUZYz1fmu2SnM7yK6rHVdUJw41Kg5K8Y5xNI+foO1V1xRBD0oDZXJezG6c0sZ2AJ1bVT0YK2m6C76iqxyZ5AvARmhkH1ZEk9wDuB6wzWF5Vn+4mIg04i6Yy+rGRgiSvBnYG/plmEeL/pUkIJd3RKcC+wFEsrajuA3yBZpKJTyf5QFW9v7MItRPwNOAXLD1HuwEn0CQVhyZ5RlV9p7sQZ7VZW5ezZU+aQJKFwMZV9Y+Bsnk0C0Ov33YhvL6q1hn3IJpSSd4EvA04E7hpYFNV1aO7iUojklxD8xlaPFA2h+YztGGSNYC/O3OqNLYkPwf2q6qzB8p2Bo6qqock2Q34YlXt0FmQs1ySY2nOwdcHyp4KPK+qnt1OVPXaqrp/VzHOZrO5LueAX2livwUOTrImQPvznTSJBcB2wNXdhKbWATQLqD+kqh41cDPRmx6uoLmyPehJwN/b+2sCtw81Imlm2RkYvcTChcA9AKrqFzRdo9Wdx9N0ERx0IrBXe/9zwPZDjUiDfsssrcuZ7EkT2xd4BHBdksuB64Dd23KAjYBXdRSbGjcD53QdhMb1GuDoJD9J8qUkPwGOAf693f4Qmm6cksZ2GvCZJDsmWTPJjsARwI8BktwHuKzLAMV5wCtHlb2iLQfYhGV7nmi4Zm1dzm6c0iQl2QrYArisqi7qOh4tlWQf4OHAgTStSEsMdh1Ud5JsQnOFewuaSum3quqqbqOSZoYkGwGHAk+nmW/hduA44N+r6sp2zPK6TnLUnSQPpDknc4BLgS1p1tx7elX9OsnuwD2q6ogOw5z1ZmNdzmRPmoQkGwNPBDavqvcn2QJYraou6Tg0scyCw4NfaMEFh6eV9p/sllX1s65jkWaiJKsB84EFXsiaftoxYA9l6UWtn1aVXdSnidlal7MbpzSBJHsAfwKeD7y1Lb478InOgtJo27W37QduI4/VsSRbt103zwF+0JY9M8mnuo1MmjnaCVneDLy1qhYnuUeS+3Ydl8ZWVacBqydZu+tYNLvrcrbsSRNI8hvgv6rqh0muaWcPXBO4sKocEC9NIMlJwOnAe4Gr2s/Q+sDvqmqbbqOTpr8k/0rTjfNrNLM7rpdkV+C9VbVnt9EJloybPJ5mXb27VdU6SZ4I7FtVz+42Os3mupzJnjSBkS+F9v7VVbVR25VmQVVt3HF4s1aSw6tq//b+MYy94DBVtc9QA9MdJLkKmN+2RlxdVRu15ddW1QbdRidNf0nOBp5TVWcOVFTnAX+rqvldxydI8mPgk1V1zMA5Whs4t6q27Dq+2W421+VcVF2a2B+TPL6qvjtQtifw+64CEgDnD9z/S2dRaDKuAHYEzh0pSHJPYFYMjpdWgU2B37X3a+CnV+ynj3vRLK8A7XmpqhuT3KW7kDRg1tblTPakif0ncGKSbwF3SfJJmjXDntptWLPez5OMrKN3eqeRaCIfpPkMvQeYm+S5wJtounVKmtivgBcCRw+UPQf4RTfhaAwXAA8ClsyI2i5278XI6WHW1uXsxilNoG3mvyvwAmAb4GLgc32fvWm6S3L+xHtRVeUkLdNAkqcCL6f5DF1E093pG50GJc0Q7eQs36Pp0fBQ4BRgJ+BxVfXnDkNTK8mTgSOBw2gSi4Np1tl7WVV9r8vYNLvrciZ70nIkmQPcAGxQVbd2HY8007SfoR8Cj/czJK24JKGZXfhK4AksraieWFU3dBmblpXkAcDLWHqOjqiqX3UblWZ7Xc5kT5pAkjOBvarqb13HIs1ESS4Edq6qm7uORZqJktxIs2i6a+tNQ20ycS5wz9mYTMwEs7ku55g9aWKfp+nn/VHgEgYGxFfVyZ1FJc0cBwGfSPJ27vgZsvIqTew3NN02z+k6EN1RVS1KsghYk2bpBU0/s7YuZ8ueNIHljA1zPJg0CUlGErrBfzih+QzN6SAkaUZJ8i6asUafpekeOFhR/XRHYWlAklfRTPbxbu6YTPy1q7jUmM11OZM9SdKUSjLuwulVdeEwY5FmoiQ/GmdTVdWjx9mmIRq4qDWaF7XUKZM9aQJJvllVd5iaN8lxVfX0LmKSJEnS5CWZC/wTsCVN6+tPq+of3UY19Uz2pAkkua6q1huj/Oqq2qiLmKSZJMkxjL348600/3C/UVVnDjcqaeZIMh+4uapuaCcD2QdYRDN1vONepQm0y5ecANyFpiv0VsAtwFOq6uwuY5tqTtAijSPJO9q7qw/cH7E9YPczaXIW0iwIfTxL/8k+BfgSsAvwhiSvqKqjxz+ENKudSLNm229oxoQ9GbgdeADw2g7jUivJ6Sz/otZxVXXCcKPSgEOBw4EPVtvSleS/2vJHdRnYVLNlTxpHks+0d59PM4vTiAKuAI6sqr8MPTBphknyPeCgqvrJQNnDgHdU1WOTPAH4SFXt3FmQ0jSW5Bpgo6qqJJfQdEW7ATirqjbvNjoBJHknsC9wFEsvau0DfIFmQqqXAB+oqvd3FuQsluRqYH5VLRoomwssqKoNu4ts6pnsSRNI8rKqOqLrOKSZKslCYOPBsRFJ5gFXVtX67aLR11fVOp0FKU1jSa6kGWe0E/ClqrpXktWAhVW1brfRCSDJz4H9BrsEtl0Hj6qqhyTZDfhiVe3QWZCzWJI/AK8ZXGYhyaOAQ6rqXt1FNvXsxilN7CdJNquqK5KsA/w3sJjmCt1NHccmzQS/BQ5O8vaquiXJmsCBwMg4ve2AqzuKTZoJTgKOBTam6f4McE/g0s4i0mg7A6OXWLgQuAdAVf0iyWZDj0oj3gQcn+REmvOyDfAkmiVNem21rgOQZoAvAhu09z8I7A48FPhkVwFJM8y+wCOA65JcDlxH8znat92+EfCqjmKTZoKXAt8CjgTe05ZtQnPRRNPDacBnkuyYZM0kOwJHAD8GSHIf4LIuA5zNqup44IHAH4B1258PqqpvdhrYENiNU5pAkoUDXc2uoLmaejNwflVt2m100syRZCtgC+Cyqrqo63ikmabturlZVZk0TDNJNqKZ7OPpwBzgH8BxwL9X1ZVJ7gGsW1VndBimZiGTPWkCSa4AdqRJ8j5eVbu2g3qvHmtJBkljS7IpsMy4vKoa3e1J0ihJNqBJJJ4J3F5VayfZG9itqt7SaXBaRpuQz6eZ+MNlMTq0nGV/llFV+wwhnM44Zk+a2BeAk2ma/Q9pyx4InN9ZRNIM0s62eSQwetbAorkCLmn5DgOuoRln9Me27KfA/wAme9NEkvVpxuit0z4GYHBSEA2VM6Zjy540KUkeR3M19Uft412B9fwClyaW5DzgAzSz0t3cdTzSTJNkAbBFVd2e5Oqq2qgtX1hV63ccnoAk+wEfp1kSY3Dytqqq7TsJSstI8ljgucCmVfXk2VKXs2VPmoSq+l6Srdu1wS61z720QjYEPlleXZTurIU0E7IsGauXZGuc8GM6ORh4ZlWd1HUguqMk/w78B/Ap4Blt8c3Ax2jWrewtZ+OUJpBk8ySnAn+mGWz9lySnJtmi49CkmeJI4EVdByHNYJ8CvtauC7Zae+HxKJrunZoe5gLf6zoIjesAYM+qei/N8lkA59AujdFnduOUJpDkG8BFwBur6sYkawPvBrarqr07DU6aAZKcDuxGs7bR5YPbqmr3ToKSZpB2NujXAC+nGbd3Ec3yPx+1xXx6SPI6mrH973Riluknyd+Bzatq0UhX6HbN1/OravR48l4x2ZMmkORKmi+I2wfK1qDpzrlJd5FJM0OSfcfbVlVHDTMWSZoKSS4G7grcBlw1uK2qtu4kKC2R5KvAb6rq4IFk7/XA/avqeV3HN5VM9qQJJPkzTT/8MwfK7gscV1U7dheZJGm2aCeXeA7N5BJPmS2TS8wUSfYYb1tVnTrMWHRHSTYHTqAZ+7ol8FfgeuDJVXX58p470zlBizSx9wM/SHIkTTe0bWjGH72106ikaSzJC6vqmPb+i8fbr6o+PbyopJlp1OQSz2yLZ8XkEjOFCd30VlWXJXkw8GCaetzFwC9mQ5dbW/akSUjyaOB5wBbA34AvVtUPu41Kmr6SfLuqntje/9E4u1VVPXqIYUkzUrt8yWOq6oIk11TVhknmAH+vqo27jm+2SvLmqjq4vf+O8farqrcNLyppWbbsSZPQdpOxq4w0SSOJXnv/UV3GIvXAujQtEQAjV+nn0YwPU3fuNnB/q86ikJbDlj1pAknmAW8BXsjSlr1jgIOryn+00gSS/KaqHjBG+RlVtWsXMUkzyWyeXELSyjHZkyaQ5MM008YfxNIxe28Fzqiq13YZmzQTJLm+qtYdVRbgqqraqKOwpBljNk8uMVOMJOFjlP+9qjbtIiYJTPakCSW5BLhfVV01ULYJcGZVbdldZNL0luTo9u6zgS+P2rwtzf+gRww1KGmGSbIa8Ejgp8B9mGWTS8wU41zUmgdc7rhKdckxe9LEsoLlkhrnjXO/gJ8AXxluONLMU1WLk3yzTSR+0d40TSQ5neY7bc0kp43afDfg/4YflbSUyZ40sa8AJyQ5CLiI5qrqW4BjO41Kmuaq6iCAJD+rqu92HY80g52W5KFV9bOuA9EdfIrm4u+DgSMHygu4Aid3U8fsxilNIMnqNMndMksvAO+qqlu7jE2aCZI8Crigqs5PclfgfcBi4I2ON5ImluRQ4LnAN2m6cC6pvDmt//SQZOeqOqfrOKTRTPYkSVMqydnA46vqoiRfaItvBuZX1d4dhibNCEk+M962qnrRMGPR2JI8F/htVZ2d5B7A4TQXtV5pEqgumexJk9Auqv5clrbsfclF1aXJSXJdVa2XZC5Nt6ZtaNYH+1tVbdJtdJK08tqF7/+pqq5IcgLwJ+AGYPeqenS30Wk2W63rAKTpLsl/Al8Crga+BVwFfKEtlzSx65JsBuwB/LGqbmjL53UYkzRjJLl6nPK/DzsWjWt+m+itCfwz8GbgHcD9O41Ks54TtEgTex3w6Kr6w0hBkmOA7wP/01lU0szxv8AvgdWBA9qyhwN2bZIm5w4XRtpp/ed0EIvGtiDJjjTLY/yyqm5NshbO3K2OmexJk/OXUY//ysAAeUnjq6r3Jfk6sKiqRpZguBR4aYdhSdOe0/rPKO8EfgUsollbFGBP4MzOIpJwzJ40pnYR2xEvoVnQ9kDgEmAr4K3AqVX1qaEHJ81A7Xi9fwK2pEn0/q+q/tFtVNL0lmRfmpahTwCvGNi0ZFr/qrq9i9h0R21LHlV1U/t4U2A1Zx1Wl0z2pDEkWczSlrvBLhiDZVVVdqGRJpBkZ+AE4C4008ZvBdwCPKWqzu4yNmkmcFr/mSHJhsBTWHpR68SqGnO8pTQsJnvSGJJsM5n9qurCqY5FmumSnAycBHyw2n86Sf4LeFJVParT4KQZop3kaDdgEwYuQlbVpzsLSkskeRjNJG7nABcCWwO70HzP/bTL2DS7mexJE0jyX1X1wTHKX1dVH+oiJmkmaWcSnF9ViwbK5gILqmrD7iKTZoYk/wJ8DvgzcC/gLODewI+9YDI9JPk58OGq+tJA2bOB/6qqB3cXmWY7l16QJva2ccrfMtQopJnrbzTLLgx6RFsuaWLvAl5UVQ8Abmx/7k8zIYimh52AY0eVfRXYsYNYpCWcjVMaR7uQOsCcJI9i2bF72wPXDz8qaUZ6E3B8khNpujdtAzwJeEGnUUkzx9ZV9ZVRZUcBlwP/1UE8uqM/A88BvjBQ9q/AeWPvLg2H3TilcSQ5v727NXDRwKai+Qf73qo6fuiBSTNQkp2AZwFb0LToHVtV53YblTQzJPkL8PB20e7fAK8CrgR+VlUbdxudAJL8E3AicC7NRa1tgbsDT64ql8hQZ0z2pAkkObqq9uk6Dmmma5c02Qy4oqoWdx2PNFMkeQPwl6r6WpJ9gMOBxcD/VNVbu41OI9rZOJ/E0ota33Y2TnXNZE+SNKWSrAccQrPQ8FzgH8CXgNdU1cIuY5NmgiSrDV4gSbI1sLZLl0w/7bnZEri0qi6aaH9pqjlBizSBJOsl+VCSXyW5MMlFI7euY5NmiI8BawP3AdYa+PmxLoOSZoIkc4Abk6wxUlZVF5noTS9JNk9yKs3YveOAvyQ5LckWHYemWc5kT5rYocADgXcAGwH/TjOG78NdBiXNIE8AXlhV51bVre1YvRe15ZKWo12y5FzAsXnT2yeAM4GNqmpzYEPgN8BhnUalWc9unNIEkvwd2KWqrkpybVVtkGRL4ISqemDX8UnTXZILgD2q6sKBsm2B06pq667ikmaKJK+nmenxo8AlNBOFAVBVJ3cVl5ZKciWweVXdPlC2Bk13zk26i0yznUsvSBNbDRgZV3RDkvWBy3DtHGmyPgV8P8mHWLr0wmtpJpmQNLFXtj8PHFVeNEsBqXvXAPekad0bcQ/g2k6ikVome9LEzqRZEPqHwOk03TpvoOlWI2liB9PMTPc8ls5S937g010GJc0UVbVd1zFoQu8HfpDkSJZe1HoR4Gyp6pTdOKUJJNkeoKr+mmRT4N3AOsBBDpCXJE21JN+sqqeOUX5cVT29i5h0R0kezbIXtb5YVT/sNirNdiZ70gSSfAz40uCiqO3iqc+qqgM6C0yaQZK8GHguSytBXwI+Xf4TkiaU5LqqWm+M8quraqMuYpI0M5jsSRNIsgDYsqpuGyhbA7i4qjbtLjJpZkjyfuCpwEdY2r3pNTSTHL2+w9CkaS3JO9q7r6fpJjhoe+BeVfWA4UalsSRZHXgLd7yodXBV3dJlbJrdHLMnTay44zIlc8YokzS2/YAHVtUlIwVJTgR+TVOJlTS2rdqfqw3ch+b/0sXcccIWdecTNBOyvIalF7XeRLPA+os7jEuznC170gSSfA04H3h9VS1OshrwXuDuVfW0bqOTpr8k59EkewsHyjYAflVVO3QWmDRDJHlZVR3RdRwaX5KrgB2q6tqBso2Av9jVVl2yZU+a2H8AJwKXJbkQ2Jpm6YWndBqVNI2NTGzU+ghwXJL30qwRthXw38CHOwhNmoluHl2QJMD/q6r3dBCP7uhyYC2WXWrhLjT1BakztuxJk9C25u1GU0m9GPhFVS3uNipp+kqymKarWZazW1XVnCGFJM1YSf5M0+35FVV1TXsx5RhgcVU9otvoZq929s0Ru9HMxPm/LL2o9W/AF6rqfR2EJwEme5IkSdNakrVpWsifAHwWeBXwQeB9XnjsTpLzJ7FbVZUL36szJnuSpCmV5GNV9Zoxyj/i8iXS5CSZD/wQuDdwFPBily6RNBFnE5QkTbX9xil/4TCDkGaqJE8CzgR+BNyXZtbH05Ns12lgWiLJN8cpP27YsUiDnKBFkjQl2oXUAeYO3B+xPXDlkEOSZqrDgH2q6gcASf4ZeDNwBrBxl4FpiUeNU/7IYQYhjWayJ0maKiMtd6uzbCteAVcA+w49Imlmui+wa5IjgU2r6ilJTgJu7TiuWW9g4fvVB+6P2J5mzT2pMyZ7kqQpUVWPAkjyrqp6S9fxSDPY84EDgE8Bz2zLbgb+BXh/NyGp5cL3mtacoEWSNBRJNgXWGSyrqr92FI40YyQ5D3hMVV2Q5Jqq2jDJHODvVWU3zmnAhe81XdmyJ0maUkkeD3wa2HzUpgJcZ0+a2Lo0rUTQfG4A5gG3dROORquqI5KsTzN5zuiLWid3E5VksidJmnqHAu8Ejqqqm7sORpqBTgP+H3DwQNlraGbn1DSQZD/g48ANwE0Dm4pm7J7UCbtxSpKmVJKrgY1dE0y6c5JsDpwAbAJsCfwVuB54clVd3mVsaiS5FHhpVZ3UdSzSIJM9SdKUSvIB4Oyq+nTXsUgzVZIADwa2oenS+YuqWtxtVBqR5Apgi6pa1HUs0iCTPUnSlEpyOrAbzRTky7RCVNXunQQlSatQktfRjK18p0m4phOTPUnSlEoy7np6VXXUMGORpKmQ5GLgrjST5lw1uK2qtu4kKAmTPUmSJGmlJNljvG1VdeowY5EGmexJkqZUO9bopcBzgU2q6r5JdgfuWlXHdhudJEn9tVrXAUiSeu8dwEuAw4GR7kyXAG/oLCJJWoWSrJHk4CR/TbKwLXtckld3HZtmN1v2JElTqh3L8oCqujLJNVW1Ydvad3VVbdh1fJK0spIcSrMsxnuBk6pqgyRbAt+rqnt1G51mMxdVlyRNtTk0Cw1Ds8AwwDoDZZI00z0N2LGqbkyyGKCqLm0TPqkzduOUJE21bwMfSrIGLBnD906aRaIlqQ9uY1QjSpL5jJqZUxo2kz1J0lR7HbA5sBBYn6ZFbxscsyepP74CHJVkO4AkmwOHAF/qNCrNeo7ZkyQNRZLNaCZoubiqLp9of0maKZKsDrwPeBmwFnATcATwhqq6rcvYNLuZ7EmSVrkkqfYfTJJxe5FU1eLhRSVJU6/tvnllWcnWNGCyJ0la5ZJcV1XrtfcXs3RiliW7AFVVc4YenCStAkm2raoL2vvbj7dfVf11aEFJozgbpyRpKgxONb5dZ1FI0tT5PbBue/8vNBe1MmqfopmRWOqELXuSJEmS1EO27EmSVrkkx3DHrpt3UFX7DCEcSZJmJZM9SdJU+MvA/U2AfWnW1buQZkbOpwBHdRCXJK0SSU5nche1dh9CONKYTPYkSatcVR00cj/Jd4EnVdXpA2X/DLy1i9gkaRX51MD9HYAX01zEGrmotS/w6Q7ikpZwzJ4kaUolWQhsUlW3D5TNA64ambFTkmayJD8DXlJVZw2U3RP4dFU9tLvINNuNu/aRJEmryG+Adye5C0D782Dgt10GJUmr0C7AeaPKzgd27iAWaQmTPUnSVNsPeDiwMMkVwELgnwEnZ5HUF6cCn01y9yR3SbITcCRw+gTPk6aU3TglSUORZGtgc+Cyqrqo63gkaVVJshFwKPB0mnX1/gEcB/x7VV3ZZWya3Uz2JElDkyQMLDpcVYs7DEeSVqkkqwHzgQV+v2k6sBunJGlKJdkiydeTXEVztfv2gZsk9cnawFrAtkm2T7J91wFpdjPZkyRNtU8CtwGPAW4AHggcD7yiy6AkaVVJcs8kv6EZk/yX9vbn9iZ1xm6ckqQp1bbobV1VNya5tqo2aMe3/F9VOVOdpBkvySnAr4F30MzCuS3wHprvuc91F5lmO5M9SdKUSvJ3YKuqujXJBcCDgeuAK6tq3U6Dk6RVIMk1wKZVdfvARa21gT9U1XZdx6fZy26ckqSp9nPgie397wJfppml7ozOIpKkVesWYF57/8p29uHVgI27C0ky2ZMkTb0X0qxBBXAAcDLwB+B5XQUkSavY6cCz2vtfBU6i+d47ubOIJOzGKUmaQknmAJ8G9q+qW7uOR5KmWrv8wvOAdYGjq+rGjkPSLGayJ0maUkkuo5mgxaUWJPVOe1Hrh8Djvail6cZunJKkqfZh4KAk8ybcU5JmmKpaBGyH9WpNQ7bsSZKmVJKLgbsCi4AFQAEBqqq27jI2SVoVkrwY2B14O3AJzfccAFW1uKu4JJM9SdKUSrLHeNuq6tTxtknSTJFkJKEbrFiPXNSa00FIEgBzuw5AktR7jxmn/NYk2wLfqaorhhiPJK1qrqWnacmWPUnSlEryJeBpwC+Ai4GtgN2AE4C7AfcBnlFV3+ksSEmSesiWPUnSVFsNeE5VfX2kIMlTgedV1UOT7Au8FzDZkzQjJTmGZbtwjriVZgzfN6rqzOFGJTlrkCRp6j0eOH5U2YnAXu39zwHbDzUiSVq1FgJPpRmnd0n7c2+aial2AX6aZJ/uwtNsZcueJGmqnQe8EjhkoOwVbTnAJsBNww5KklahnYAnVtVPRgqSPAx4R1U9NskTgI8AR3cUn2Ypx+xJkqZUkgcCxwFzgEuBLWmudj+9qn6dZHfgHlV1RIdhStKdlmQhsHFV/WOgbB5wZVWtnyTA9VW1TmdBalYy2ZMkTbm20vNQYAvgMuCnVXV7t1FJ0qqR5FTgZ8Dbq+qWJGsCBwL/VFW7J9keOMW1RTVsJnuSJEnSSkiyHfB5YFfgamAj4AzgBVX11yS7AnetqhM7DFOzkMmeJEmStAok2Yq2B0NVXdR1PJLJniRJkrQSkvymqh4wRvkZVbVrFzFJ4NILkiRJ0sracXRBOymLy8qoUy69IEmSJN0JSUaWUlh94P6IbYGzhhuRtCyTPUmSJOnOOW+c+wX8BPjKcMORluWYPUmSJGklJHl8VX236zik0RyzJ0mSJK2c29rlF0hy1yRHJflMkrt2HZhmN5M9SZIkaeUcCixq738ImAcsBg7vLCIJu3FKkiRJKyXJdVW1XpK5wBXANsBtwN+qapNuo9Ns5gQtkiRJ0sq5LslmwL2BP1bVDUlWp2nhkzpjsidJkiStnP8FfgmsDhzQlj0cOKergCSwG6ckSZK00pLsBCyqqvMGHq9RVb/vNjLNZiZ7kiRJktRDduOUJEmSVlCSs6tql/b+xTQLqd9BVW091MCkASZ7kiRJ0op72cD9F3QWhbQcduOUJEmSVkI78+Z+wP2BdQa3VdU+HYQkAbbsSZIkSSvrKOB+wAk06+xJ04Ite5IkSdJKSHINsF1VXdt1LNKg1boOQJIkSZrhLgLW6DoIaTRb9iRJkqQVlOTRAw8fAPwr8FFGdeOsqpOHGZc0yGRPkiRJWkFJzp/EblVV2095MNI4TPYkSZIkqYccsydJkiRJPWSyJ0mSJEk9ZLInSZIkST1ksidJkiRJPWSyJ0mSJEk99P8Bt1wwAQnWWqgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "graph_cv_model_performance(ensemble_results_df, sort=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "varied-second",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T08:28:51.245431Z",
+     "start_time": "2021-02-15T08:28:51.200576Z"
+    }
+   },
+   "source": [
+    "### Lone Ridge performs better than any stacking ensemble\n",
+    "\n",
+    "As expected, the accuracy of the ensemble increased with more base estimators, until it tapered off as we reached a point of diminishing returns. However, the highest accuracy was still slightly lower than it was for a lone Ridge model, which is a little surprising. Perhaps `ExtraTreesRegressor` isn't well-suited to this new mix of base estimators."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "capital-evening",
+   "metadata": {},
+   "source": [
+    "## Try different meta-estimators\n",
+    "\n",
+    "Taking the original mix of estimators used to find good base estimators for the stacking ensemble and using them as meta-estimators on top of the best-performing mix of base estimators from section 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "expired-southwest",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T20:39:54.295910Z",
+     "start_time": "2021-02-15T20:39:53.701449Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['ridge',\n",
+       " 'catboostregressor',\n",
+       " 'linearsvr',\n",
+       " 'gradientboostingregressor',\n",
+       " 'svr',\n",
+       " 'extratreesregressor',\n",
+       " 'histgradientboostingregressor',\n",
+       " 'voting']"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "meta_ensembles = []\n",
+    "\n",
+    "base_estimators = [\n",
+    "    Ridge(),\n",
+    "    CatBoostRegressor(random_seed=SEED),\n",
+    "    LinearSVR(),\n",
+    "    GradientBoostingRegressor(random_state=SEED),\n",
+    "    SVR(kernel='rbf'),  \n",
+    "    ExtraTreesRegressor(random_state=SEED),\n",
+    "]\n",
+    "regressors = [\n",
+    "    make_pipeline(\n",
+    "        DataFrameConverter(), BASE_ML_PIPELINE, base_estimator\n",
+    "    ) for base_estimator in base_estimators\n",
+    "]\n",
+    "    \n",
+    "for meta_estimator in top_estimators:\n",
+    "    pipeline = StackingRegressor(\n",
+    "        regressors=[*regressors],\n",
+    "        meta_regressor=make_pipeline(\n",
+    "            StandardScaler(), meta_estimator\n",
+    "        )\n",
+    "    )\n",
+    "    meta_ensembles.append(StackingEstimator(pipeline=pipeline))\n",
+    "\n",
+    "meta_ensembles.append(\n",
+    "    VotingRegressor(\n",
+    "        [(regressor.steps[-1][0], regressor) for regressor in regressors]\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "[\n",
+    "    ensemble.pipeline.meta_regressor.steps[-1][0]\n",
+    "    for ensemble in meta_ensembles[:-1]\n",
+    "] + ['voting']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "boolean-organic",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-15T22:30:04.739853Z",
+     "start_time": "2021-02-15T20:41:47.609495Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 15.4min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 14.6min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 14.0min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 13.7min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 12.7min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 12.3min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 11.3min finished\n",
+      "[Parallel(n_jobs=-1)]: Using backend LokyBackend with 4 concurrent workers.\n",
+      "[Parallel(n_jobs=-1)]: Done   5 out of   5 | elapsed: 14.2min finished\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[{'fit_time': array([522.64389515, 553.12044954, 567.9936285 , 588.03602934,\n",
+       "         367.22527528]),\n",
+       "  'score_time': array([ 8.04998636, 10.08305144,  7.11699605,  5.22632194,  5.40955114]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.47798111, -29.20153787, -28.05378873, -26.19498761,\n",
+       "         -27.93605031]),\n",
+       "  'test_match_accuracy': array([0.7184466 , 0.73429952, 0.67149758, 0.7294686 , 0.65217391])},\n",
+       " {'fit_time': array([476.90565968, 510.49309778, 528.43991971, 543.55589628,\n",
+       "         383.36963463]),\n",
+       "  'score_time': array([ 6.29383063, 11.92398357,  7.06984067,  6.34693289,  5.0892899 ]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.50565733, -29.22078046, -28.04139136, -26.21248429,\n",
+       "         -27.93377829]),\n",
+       "  'test_match_accuracy': array([0.71359223, 0.73913043, 0.67149758, 0.72463768, 0.65700483])},\n",
+       " {'fit_time': array([468.15937638, 487.91700864, 509.21703959, 521.31605601,\n",
+       "         358.08889723]),\n",
+       "  'score_time': array([6.50025272, 8.36914062, 7.72844625, 5.71874452, 4.99547124]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.47849515, -29.20202899, -28.05427536, -26.19509662,\n",
+       "         -27.9365942 ]),\n",
+       "  'test_match_accuracy': array([0.7184466 , 0.73429952, 0.67149758, 0.7294686 , 0.65217391])},\n",
+       " {'fit_time': array([461.75430942, 502.86738467, 524.94837856, 539.13427758,\n",
+       "         350.73476624]),\n",
+       "  'score_time': array([ 7.03383183, 10.12480664,  6.03234291,  6.90929937,  4.67313743]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.457022  , -29.24443597, -28.05439045, -26.20927753,\n",
+       "         -27.92774167]),\n",
+       "  'test_match_accuracy': array([0.7184466 , 0.73429952, 0.67149758, 0.72463768, 0.647343  ])},\n",
+       " {'fit_time': array([443.98551345, 453.93493581, 481.69128633, 476.82247925,\n",
+       "         308.94134903]),\n",
+       "  'score_time': array([5.39813542, 6.83666754, 5.45239568, 5.21405292, 4.69377995]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.49538599, -29.3109817 , -28.08340398, -26.29700211,\n",
+       "         -27.92418748]),\n",
+       "  'test_match_accuracy': array([0.71359223, 0.7294686 , 0.67149758, 0.72463768, 0.65217391])},\n",
+       " {'fit_time': array([394.67283869, 426.9889257 , 447.86771178, 456.65553522,\n",
+       "         333.69687724]),\n",
+       "  'score_time': array([6.31472468, 7.36687899, 5.70031095, 5.12568998, 5.03118205]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.46737864, -29.19908213, -28.05678744, -26.19454106,\n",
+       "         -27.9352657 ]),\n",
+       "  'test_match_accuracy': array([0.7184466 , 0.73429952, 0.67149758, 0.72463768, 0.65217391])},\n",
+       " {'fit_time': array([377.36923552, 389.52417469, 409.77821827, 415.74011064,\n",
+       "         290.14176965]),\n",
+       "  'score_time': array([5.39395738, 5.89353013, 4.56651211, 4.27376938, 4.22248793]),\n",
+       "  'test_neg_mean_absolute_error': array([-30.47656156, -29.20356083, -28.04547645, -26.23325142,\n",
+       "         -27.94855384]),\n",
+       "  'test_match_accuracy': array([0.7184466 , 0.73429952, 0.67149758, 0.71980676, 0.65217391])},\n",
+       " {'fit_time': array([458.24809718, 486.30127096, 508.49715304, 512.23840213,\n",
+       "         377.72714424]),\n",
+       "  'score_time': array([6.75465131, 8.41566515, 6.84672356, 7.38863492, 6.65468478]),\n",
+       "  'test_neg_mean_absolute_error': array([-29.81581789, -29.16252902, -28.67988487, -26.16991657,\n",
+       "         -27.00384909]),\n",
+       "  'test_match_accuracy': array([0.72815534, 0.71014493, 0.6763285 , 0.74396135, 0.64251208])}]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "meta_scores = []\n",
+    "\n",
+    "for ensemble in meta_ensembles:\n",
+    "    scores = score_model(ensemble, data, n_jobs=-1)\n",
+    "    meta_scores.append(scores)\n",
+    "\n",
+    "meta_scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "mechanical-ivory",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-16T00:49:12.231243Z",
+     "start_time": "2021-02-16T00:49:12.077948Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>fit_time</th>\n",
+       "      <th>match_accuracy</th>\n",
+       "      <th>mae</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ridge</td>\n",
+       "      <td>519.803856</td>\n",
+       "      <td>0.701177</td>\n",
+       "      <td>28.372869</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>catboostregressor</td>\n",
+       "      <td>488.552842</td>\n",
+       "      <td>0.701173</td>\n",
+       "      <td>28.382818</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>linearsvr</td>\n",
+       "      <td>468.939676</td>\n",
+       "      <td>0.701177</td>\n",
+       "      <td>28.373298</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>gradientboostingregressor</td>\n",
+       "      <td>475.887823</td>\n",
+       "      <td>0.699245</td>\n",
+       "      <td>28.378574</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>svr</td>\n",
+       "      <td>433.075113</td>\n",
+       "      <td>0.698274</td>\n",
+       "      <td>28.422192</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>extratreesregressor</td>\n",
+       "      <td>411.976378</td>\n",
+       "      <td>0.700211</td>\n",
+       "      <td>28.370611</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>histgradientboostingregressor</td>\n",
+       "      <td>376.510702</td>\n",
+       "      <td>0.699245</td>\n",
+       "      <td>28.381481</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>voting</td>\n",
+       "      <td>468.602414</td>\n",
+       "      <td>0.700220</td>\n",
+       "      <td>28.166399</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           model    fit_time  match_accuracy        mae\n",
+       "0                          ridge  519.803856        0.701177  28.372869\n",
+       "1              catboostregressor  488.552842        0.701173  28.382818\n",
+       "2                      linearsvr  468.939676        0.701177  28.373298\n",
+       "3      gradientboostingregressor  475.887823        0.699245  28.378574\n",
+       "4                            svr  433.075113        0.698274  28.422192\n",
+       "5            extratreesregressor  411.976378        0.700211  28.370611\n",
+       "6  histgradientboostingregressor  376.510702        0.699245  28.381481\n",
+       "7                         voting  468.602414        0.700220  28.166399"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = []\n",
+    "\n",
+    "for idx, scores in enumerate(meta_scores):\n",
+    "    model_name = meta_ensembles[idx].pipeline.meta_regressor.steps[-1][0] if idx < len(meta_scores) - 1 else 'voting'\n",
+    "    results.append(\n",
+    "        {\n",
+    "            'model': model_name,\n",
+    "            'fit_time': scores['fit_time'].mean(),\n",
+    "            'match_accuracy': scores['test_match_accuracy'].mean(),\n",
+    "            'mae': abs(scores['test_neg_mean_absolute_error'].mean()),\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "meta_results_df = pd.DataFrame(results)\n",
+    "meta_results_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "vanilla-beverage",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-02-16T00:49:24.919652Z",
+     "start_time": "2021-02-16T00:49:23.244120Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.8/site-packages/ipykernel/ipkernel.py:283: DeprecationWarning: `should_run_async` will not call `transform_cell` automatically in the future. Please pass the result to `transformed_cell` argument and any exception that happen during thetransform in `preprocessing_exc_tuple` in IPython 7.17 and above.\n",
+      "  and should_run_async(code)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-16 00:49:23,779 - matplotlib.legend - WARNING - No handles with labels found to put in legend.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA44AAAJwCAYAAADGGD9JAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABf/UlEQVR4nO3dd7xkdX3/8debKm2pS5GOiAUVMIhEBBW7RrHFglKM3SQaidFo5CdgbxiNFRUFVFARFCS2iNIUFaOoCwbpHZa2sEuHz++Pcy47Ozt39i7szpnd+3o+HvO4c7/nzJnP7Mzcnfd8v+f7TVUhSZIkSdJkVui6AEmSJEnSeDM4SpIkSZKGMjhKkiRJkoYyOEqSJEmShjI4SpIkSZKGMjhKkiRJkoYyOErSGEqyf5JK8uT7efsnt7fff4kWpsWWZOsk30syu31OvtZ1TZpv0HslyVZt20FTPMbXkiyV9c2SHNTWstXSOL4kTZXBUZL69HyQrCSfmWSfDZPc2e7zixGXqGXL14AnAR8B9gG+2Gk1GjtJXjDVkCpJXTE4StLkbgf2TrLqgG37AAHuHm1JWpa0r53dgaOq6uNV9fWq+lXXdWmRLgFWA94/ovt7AfDeSba9v63lkhHVIkkDGRwlaXLHA+sCew3Y9mrgv4E7RlqRFpDGml3XMcRGNF8w3LCkD5xkrSV9zFEce1lQjdurqvMvhqrq7raWpTIUVpKmyuAoSZP7X+CPNCHxPkl2AbYHvjrZDduhZ2ckmZdkbnt9UAAlyeuS/CXJHUnOT/IvNGFj0L5rJ/lIu98d7XlzRyfZ5v4+yCQPTvKJJH9IcmOS25Ock+SdSVYcsP8qSd7R7n9rkjlJzkryT337zUjygSTntse8PsnpSV7es88vklw84D4WOses91y0JP+Y5ByaXuG3t9t3ac81O6+t65b23/2FkzzujZN8OsmF7b/ltUl+muTp7fbvt8eZMeC2j2tr+X9D/l2/xvxeovf2DH9+crt9pfbf+Jyef5/jkzx6sn+LJC9L8rsktwH/Ndl999x2pyTfSXJN+xgva18vD+nZp9p/t6e2z89c4MSe7VN6LSd5QpIfJrm6fTxXJPnvJLv27LNekk8muaDnMf8uyb8t4nGs0+5/3CTbP9Q+jh3b3xfrNT3geAPPcUzyoCQfS3JlktuS/CbJMyY5xpRej2mGuu/XXq+ey/5t28BzHNsaj+p5bi9I8sEkq/ftN3H7h7XbL2/3PzvJcxb1byFJE1bqugBJGnOHA4cm2bSqrmjb/gG4FvjBoBskeTPwWeAvwCFt8/7A95K8oaoO69n3X4BPAmcD7wZWpwlC1w447trAL4Et2rpmAZsAbwZ+nWTnqro/w9keA7yIpof1AmBl4FnAh4FtgDf01LAK8GPgycBPgK/ThLdHt8f4TLvfOsDpNAH7WODzwIrATsDfAcfcjzon/AuwPvAl4Grgsrb9hcDDgW/TBLb1aT6QH5fklVX1zZ7HsRVwBk2P4JHAWcAawK7A04Cftsd/PvAKFj4v8TXAvTTPw2S+CPyB5vk9HpgIPee2P78BvLS9r88DGwP/CPwqye5V9fu+470AeEu77xeAm4fcN0n+DvguMA/4MnB+ex/PBB5F81xP2Bl4cfuYj+g5xpRey0ke1j6Oq4FPAdfQ/Ns+EdgBOLO97XeAPdr6/0gzBPMRNK+nj032WKrqpiQnAHslWa+q7uvBTbIC8Ergj1X1h7Z5yq/pxXQ0zfNwIs374CE0z+tFA/ad6uvxAzRf5O9OMwR+wi8nKyLJlsBvgLWBzwF/pfk3fBewW5KnDugtPQK4C/g4sArN++h7SbarqosX+cglqaq8ePHixUvPheYDWNEEuPVphqO+u922GnAT8PH297nAL3puu27bdj4wo6d9Bs0H2FuAddq2dWg+1J8DrN6z72btMQp4ck/7p4DbgB366t2SJkR8bcBj2H8Kj3c1IAPajwLuATbpaXtHe9wPDth/hZ7rn2v3e/0i9vsFcPGAfbZqb3/QgMd0A7DhgNusMaBtdeD/gHP62v+7PdYzJ6uPJuheCvxmwDHnAP89hX/bhR5H2/70tv1bvf/2NCHrbuC0Ace4C3jEFF/DqwOzab6A2HQRz0G1l6f17bM4r+W3tMfYZUhNa7f7fO5+vi+f297+zX3tT23bD7ifr+mF3iuTvP6e0bZ9re+YL5j4N3wAr8ev9d++Z9tB7fG36mn7Rtv2nL59P9a2v2bA7X/Q91p7XNv+ofvzfHjx4mX6XRyqKklDVNX1wAk0vSzQ9GKszeQ9TU+n6bn6dFXd1yPUXv80sCZNjxY0H0RXBz5bVbf27Hs5zQfD+yQJTa/KqcAVSTaYuNCEzzPb492fx3hbVVV7P6u0wwk3oOlRWYGmN2rCK4Ebmd/71Huce9tjrAC8HDi3enpX+/d7AI6sqoV6ZKtq3sT1JKsnWZ/m3/dk4BFph5wmWY+m9+lHVfXjyeqrqntonufHZcHhoy+hCU9feQCPYWK44gcm/u3b+zybpjfriUlm9t3mpKo6l6l5JrAB8Ima31N+nwHPwdlV9T99bYvzWp7T/twryYMmqek2mi9hHt8/7HKKfkzTk7lvX/u+NGH7vvfMYr6mp+oF7c8Fekar6ns0YZC+9im9HhdX+/56PvD7qvrvvs0foukJHzQ8+1N9r7Xf0nwx8ND7U4ek6cfgKEmL9lXgoUmeSDNM9TdVdc4k+27d/pw1YNtE2zZ9P/8yYN/+48+k6f18Bk1PUv/l6TRDAxdbmnPt3pPkPJphp9e3xzyq3WXdnt0fCvylqm4fcsgN2tv84f7UMwXnDWpMs0TKYUmuoQnT19E8jje2u6zT/tyW5hzS/qGgg3yFpofqNT1tr6HpyTthsSufb2uaD/iDguCsnn16DXzck5gIA1N5jJMde3Fey8cA/0Mz3PqGJCe35xNuOXGDqrqTZnjko4CLksxK8l9Jntp74CQz05x/OnGZ2d5+Ihw+Psl27b5r0HyZ85OquqbnGIvzmp6qbWies0H/Vgs9j4vxelxcM2lC+0LPSzVDeK9i/vPS68IBbdfT/F2RpEUyOErSov0YuIJmuvynMPy8tqVlYrKc/6EJiYMuz7yfxz4UeB/NZECvBp7THu+d7fal+X/FZDNFDjsH/9b+hrZH9ic055AdAbyMplfx6cDEuWSL/Tiq6jLgR8Cr2p6rh9Kco3dkVd21uMd7gBZ63ONy7Kq6o6qeDjyeptfrHppe6b/0TgZTVV+gGQb6OprX20uA/0nSe87rb2nCz8Tltz3bjmx/TvQ6vogmRB3Bgrp8TS+11+MDdM8k7QMn4pKkfk6OI0mLUFX3JDmSZuKJ22gmyJjMxLf62wM/69v2yL59Jn4+fMi+E2bTnFs5Y8CQwgdqH+DUqnp5b2OSbQfsex7w8CSrVtVkS5FcRzOcdYcp3PcNwN8MaF/cWWIf097fIVW1wHp4SV7bt+/5NIF1xyke+zCa8+teQDO5DzywYarQPPcr0EwM88e+bRPP/aAJV6ZqoldsR5oAc38szmsZgKr6Dc2kLSTZnKbH8/00k9RM7HMVzWQ9X25nOD0KeEWST7TDJ19Jc47ihNt6bnt2krNpgvyBNAHyJhbu/V2c1/RUTTxn27Fwb98j+n5fnNcjTP4FyiCzac4v3b5/Q5J1aSbM+sNiHE+SpsQeR0mami8ABwNv7D3fa4Cf0gxL++f0rIXXXv9nmnOKftqz723AP/ZOoZ9kM2Dv3oO256R9A9glyUsG3XGSDRf3QbXuoa/XoR0C+LYB+36DZpjfewbcf3pqPRp4ZJLXTLZf6zxgrTRLnExsX2GS+17UY4CFH8ej6Dvfqx3O90Pg2UmeRp+++gBOAq6kmYlzP+CMqho0vHhxfK/9+a7e+2vrfT5welXNfgDH/wlNgP/XJJv0bxzwGAeZ8mu5PX+w3+U0IWe9dp/V07dURHse6URwXq9tO6Oq/qfnckbfcY+gmRBqb2BP4FsDhk4vzmt6qr7f/lxg6ZAkLwAeNuD+GVDDQq/H1tx2+3qLKqJ9f50I7JTkWX2b/53ms93xC91Qkh4gexwlaQqq6lKa2QkXtd9NSd5Bs4TBr9Os5QfN5DrbAm+oqjntvje2vSYfB37Z9mquTnMO1F+Z37s14T+A3YBvJ/k2zYQ4d9J8iH4O8DvmT+KzOI4F3pDkWzRDYTeiOZfz+gH7fgp4HvCeJI+jCSi30/R+PIz5k6W8h+ZD/ZfTrHN3Os2H6J1o/u+ZWHbgMOBfgeOTfKp9PC9h8f9/OpemF+gdbTj5P5qeoTcAf2LhXs1/olnu4IdJjqD5t1uNZqjlxcwf0jjR43w488PyuxeztoVU1U/b5/DlwLpJfsD85Thup5ml9IEc/9Y2tB8L/DnJxHIcM2mGNB/K/CA02TGm/FqmeT08g2bmzotonuvn0fSmf7TdZzvglCTHA3+m6ZV+BPCm9janTfHhfaM95udoQlL/MFVYvNf0lFTVj5OcCOzXBrwf0SzH8Yb28TyqZ/fFfT2eSfOa/FySk2hm0P11VU3W6/xummGv30vyOZrndg+aIbGnMvjfRJIeEIOjJC1hVfW5JFfR9ExMDFM7G3hhOwNj776fSLPg+gE054ZdRhMk59B3LmVVzUmyG03QeimwF81skpfTBLMv38+SD6AZ+jZxzMtoAt1vaT5099ZwZxsQ/pWmx+eDNEHnrzSTCE3sd2OSv6X5gPsiml6WW2gm/fmvnv0uantsPkhzTtr1NEMXD2fwpEEDteHuuTT/dvvRzAb65/b6DvR9UG/vd2fgQJrQvS9NkDm7fez9vtw+lnk0axEuCa+kOQdvf+AT7bFPAQ6sqj890INX1QnthE7vppnQZy2aWUlPowkvUznGVF/L36MZIvlSmpB2G81r4nXMH9Z7Gc3z+hSaYb+r0pw7/CXgI70zCy+ipmuT/IhmPdC/VtWvBuw25df0YnoZzdDbV9IEtz/RvL73pic4Lu7rkaaHfieaLxL+niYQv5pJhitX1SVJHk9zHumraCbauZzmb8j7a+E1HCXpAUvPzMySJGmAdrjnZcBXqur+Lh4vSdIyy3McJUlatDcBKzK4N1KSpOWeQ1UlSZpEkpcDW9AM1fxxVf2u45IkSeqEQ1UlSZpEkqI5h/M04NVVdUXHJUmS1AmDoyRJkiRpKM9xlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNtVLXBYyLDTbYoLbaaquuy5AkSZKkTvzud7+7rqpmDtpmcGxttdVWnHXWWV2XIUmSJEmdSHLJZNscqipJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayllVJUmSJGkZdu+993Lddddx0003cc899wzcZ8UVV2SdddZhgw02YIUVFr//0OAoSZIkScuwyy+/nCRstdVWrLzyyiRZYHtVcdddd3HNNddw+eWXs8UWWyz2fThUVZIkSZKWYfPmzWPTTTdllVVWWSg0AiRhlVVWYdNNN2XevHn36z4MjpIkSZK0jJvK8NP7M0T1vtve71tKkiRJkqYFg6MkSZIkaSiDoyRJkiRpKIOjJEmSJGkog6MkSZIkLeOqaonsMxmDoyRJkiQtw1ZeeWVuu+22Re532223sfLKK9+v+zA4SpIkSdIybMMNN+SKK67g1ltvHdirWFXceuutXHHFFWy44Yb36z5WeqBFSpIkSZK6M2PGDACuvPJK7rrrroH7rLzyymy00Ub37bu4Rhock6wHfAV4BnAd8K6q+uaA/X4I7N7TtArwf1X16CQbAp8CngSsAfwZOKCqft3e9snAycCtPbf/x6o6Yok/IEmSJEkaAzNmzLjfoXAqRt3j+FngTmAjYEfgpCRnV9Ws3p2q6tm9vyf5BU0YBFgT+C1wAHAt8Jr2OFtV1dx2nyurarOl9SAkSZIkaToZ2TmOSdYAXgwcWFVzq+p04ARgn0Xcbiua3scjAarqwqo6tKquqqp7quowmh7Jhy3VByBJkiRJ09QoJ8fZDri7qs7raTsb2H4Rt9sXOK2qLh60McmONMHx/J7mDZNck+SiJJ9sQ+ug274+yVlJzpo9e/ZUH4ckSZIkTSujDI5rAjf3tc0B1lrE7fYFvjZoQ5IZwFHAwVU1p23+C80w2E2APYG/AQ4ddPuqOqyqdq6qnWfOnDmFhyBJkiRJ088og+NcoP9szRnALZPdIMkTgY2BYwdsWw04ETizqj400V5VV1fVOVV1b1VdBLyDZoisJEmSJOl+GGVwPA9YKclDe9p2AGZNsj/AfsBxPZPeAJBkVeB7wOXAGxZxv4XrVUqSJEnS/TayQFVV84DjgEOSrJFkN2AvmqGmC2l7FF9K3zDVJCvT9EDeBuxXVff2bX9Kki3T2Bz4MPD9Jf14JEmSJGm6GHVP3JuB1WiW0TgaeFNVzUqye5K5ffu+ALgJ+Hlf+xOAv6NZC/KmJHPby8S6jzsBvwTmtT//BLxlKTwWSZIkSZoWUlVd1zAWdt555zrrrLO6LkOSJEmSOpHkd1W186BtnvsnSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGmqkwTHJekmOTzIvySVJ9p5kvx8mmdtzuTPJn3q2b5Xk50luTfKXJE/ru/3bklyd5OYkhydZdWk/NkmSJElaXq004vv7LHAnsBGwI3BSkrOralbvTlX17N7fk/wCOLmn6WjgV8Bz2suxSR5aVbOTPBP4d2BP4ErgeODgtm2J+Jt/O3JJHWra+93H9l3ix7z0kEcv8WNOZ1v8vz8teqfFtNt/7bbEjzmdnfHPZ3RdgiRJWs6NrMcxyRrAi4EDq2puVZ0OnADss4jbbQXsDhzZ/r4d8FjgvVV1W1V9F/hTe2yA/YCvVNWsqroReB+w/5J/RJIkSZI0PYyyx3E74O6qOq+n7WzgSYu43b7AaVV1cfv79sCFVXVL33G279n+/b5tGyVZv6quv7/FS9J0csoei/rTrKl60qmnLPFjfuZfT1zix5zO/ukTz+u6BEkae6M8x3FN4Oa+tjnAWou43b7A1/qOM2fIcfq3T1xf6H6SvD7JWUnOmj179iLKkCRJkqTpaZQ9jnOBGX1tM4BbBuwLQJInAhsDxy7Gcfq3T1xf6H6q6jDgMICdd965hpcvSZI0NR941Uu6LmG58R9fP3bROy2mcz9w8qJ30pQ94j/27LoEjcAoexzPA1ZK8tCeth2AWZPsD835isdV1dyetlnANkl6exB7jzOr/b132zUOU5UkSZKk+2dkPY5VNS/JccAhSV5LM6vqXsATBu2fZDXgpcAL+45zXpI/AO9N8h7g2cBjmD85zpHA15J8g2ZW1few4FBXSZIkSWPsoIMO6rqE5cqS+Pcc6TqOwJuB1YBraZbUeFNVzUqye5K5ffu+ALgJ+PmA47wc2Bm4Efgw8JKqmg1QVT8CPtre7lLgEuC9S/yRSJIkSdI0MdJ1HKvqBppA2N9+Gs2kNr1tR9OEy0HHuRh48pD7ORQ49P5XKkmSJEmaMOoeR0mSJEnSMsbgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkayuAoSZIkSRrK4ChJkiRJGsrgKEmSJEkaaqTBMcl6SY5PMi/JJUn2HrLvY5OcmmRukmuSvLVt36Jt671Ukn9ttz85yb192/cb1WOUJEmSpOXNSiO+v88CdwIbATsCJyU5u6pm9e6UZAPgR8DbgGOBVYDNAKrqUmDNnn23Bs4HvttziCurarOl9zAkSZIkafoYWY9jkjWAFwMHVtXcqjodOAHYZ8DuBwA/rqpvVNUdVXVLVZ07yaH3BU6tqouXSuGSJEmSNM2NcqjqdsDdVXVeT9vZwPYD9t0VuCHJL5Ncm+TEJFv075QkNMHxiL5NG7bDWy9K8sk2tEqSJEmS7odRBsc1gZv72uYAaw3YdzNgP+CtwBbARcDRA/Z7Is2w12N72v5CMwx2E2BP4G+AQwcVlOT1Sc5Kctbs2bOn/EAkSZIkaToZZXCcC8zoa5sB3DJg39uA46vqt1V1O3Aw8IQka/fttx/w3aqaO9FQVVdX1TlVdW9VXQS8g2aI7EKq6rCq2rmqdp45c+b9fFiSJEmStHwbZXA8D1gpyUN72nYAZg3Y949A9fxe/TskWQ34exYeptqvcNkRSZIkSbrfRhaoqmoecBxwSJI1kuwG7AUcNWD3rwIvTLJjkpWBA4HTq2pOzz4vBG4Eft57wyRPSbJlGpsDHwa+vxQekiRJkiRNC6PuiXszsBpwLc05i2+qqllJdk/SO9z0ZODdwEntvtsC/Ws+7gccVVX9vZE7Ab8E5rU//wS8ZSk8FkmSJEmaFka6jmNV3QC8YED7afSszdi2fR74/JBjPXOS9kOZZDIcSZIkSdLi89w/SZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lBTCo5JXpBkxaVdjCRJkiRp/Ey1x/EbwBVJPpJku6VZkCRJkiRpvEw1OG4MvBd4EnBuktOTvDrJGkuvNEmSJEnSOJhScKyqW6rqi1W1K/AY4NfAh4Crknwpya5Ls0hJkiRJUncWe3KcqpoFfBI4DFgFeBlwWpJfJ3nMEq5PkiRJktSxKQfHJCsneWmSHwEXAXsCbwQ2ArYEzgW+tVSqlCRJkiR1ZqWp7JTkv4BXAAUcBRxQVef07HJbkn8HrlzyJUqSJEmSujSl4Ag8Evgn4LiqunOSfa4DnrJEqpIkSZIkjY0pBceqeuoU9rkbOOUBVyRJkiRJGitTOscxyQeSvHFA+xuTvG/JlyVJkiRJGhdTnRxnH+D3A9p/B+y75MqRJEmSJI2bqQbHDYHZA9qvp5lVVZIkSZK0nJpqcLwU2H1A+x7A5VO9syTrJTk+ybwklyTZe8i+j01yapK5Sa5J8taebRcnua3dNjfJT/pu+7YkVye5OcnhSVadao2SJEmSpAVNdVbVLwKfTLIKcHLb9lTgQ8BHFuP+PgvcSdNLuSNwUpKzq2pW705JNgB+BLwNOBZYBdis71jPq6r/6b+DJM8E/p1mnckrgeOBg9s2SZIkSdJimuqsqp9ow9ynaUIcNAHwU1X10akcI8kawIuBR1XVXOD0JCfQnD/ZH+oOAH5cVd9of78DOHcq9wPsB3xlIoy2k/d8Y8B9SJIkSZKmYKpDVamqdwEbALu2l5lVtThhbDvg7qo6r6ftbGD7AfvuCtyQ5JdJrk1yYpIt+vb5RpLZSX6SZIee9u3b4/bex0ZJ1l+MWiVJkiRJrSkHR4CqmldVv20vcxfzvtYEbu5rmwOsNWDfzWh6Dt8KbAFcBBzds/2VwFbAlsDPgR8nWafnfub03QeD7ifJ65OcleSs2bMHzf0jSZIkSZrqOY4keQrwCpogt0rvtqracwqHmAvM6GubAdwyYN/bgOOr6rftfR8MXJdk7aqaU1Vn9Oz7oST70Uzec+KA+5m4vtD9VNVhwGEAO++8c03hMUiSJEnStDOlHsck+wM/pOm1ezLN0hzrAo8FzpnifZ0HrJTkoT1tOwCzBuz7R6A3yC0q1BWQ9vqs9ri993FNVV0/xTolSZIkST2mOlT17cA/VdUrgLuAd1XVTsDXaXr4Fqmq5gHHAYckWSPJbsBewFEDdv8q8MIkOyZZGTgQOL2q5iTZIsluSVZJ8qAk/0Zz7uVEL+SRwGuSPLIdvvoe4GtTfJySJEmSpD5TDY7bABNLX9xBcx4hwGeA/Rfj/t4MrAZcS3PO4puqalaS3ZPcF0Cr6mTg3cBJ7b7bAhNrPq4FfB64EbgCeBbw7Ikexar6EfBRmnMfLwUuAd67GDVKkiRJknpM9RzH65k/ucwVwKNohpOuTxMEp6SqbgBeMKD9NOaH0Ym2z9MExP59ZwGPWcT9HAocOtW6JEmSJEmTm2pwPA14BvAn4NvAp5M8HXgq8NOlVJskSZIkaQxMNTj+E/Cg9vqHgLuB3WhC5PuXQl2SJEmSpDGxyOCYZCXg5cD3AKrqXuAjS7csSZIkSdK4WOTkOFV1N/AxYOWlX44kSZIkadxMdVbVM4G/WZqFSJIkSZLG01TPcfwS8PEkWwC/A+b1bqyq/13ShUmSJEmSxsNUg+M325+DlrgoYMUlU44kSZIkadxMNThuvVSrkCRJkiSNrSkFx6q6ZGkXIkmSJEkaT1MKjkleNGx7VR23ZMqRJEmSJI2bqQ5VPXaS9mp/eo6jJEmSJC2nprQcR1Wt0HsBVgEeD5wG7LE0C5QkSZIkdWuq6zguoKrurqrfAu8GPrdkS5IkSZIkjZP7FRx73AQ8ZAnUIUmSJEkaU1OdHOex/U3AJsA7gd8v6aIkSZIkSeNjqpPjnEUzEU762s8EXr1EK5IkSZIkjZWpBset+36/F5hdVbcv4XokSZIkSWNmSsGxqi5Z2oVIkiRJksbTlCbHSfKBJG8c0P7GJO9b8mVJkiRJksbFVGdV3YfBk+D8Dth3yZUjSZIkSRo3Uw2OGwKzB7RfD2y05MqRJEmSJI2bqQbHS4HdB7TvAVy+5MqRJEmSJI2bqc6q+kXgk0lWAU5u254KfAj4yNIoTJIkSZI0HqY6q+onkmwAfBpYpW2+E/hUVX10aRUnSZIkSereVHscqap3JXk/8Mi26dyqmrt0ypIkSZIkjYspBcckGwMrVdXlwG972jcD7qqqa5ZSfZIkSZKkjk11cpyvA88e0P5M4KglV44kSZIkadxMNTjuDJw6oP20dpskSZIkaTk11eC4ErDqgPYHTdIuSZIkSVpOTDU4/hp404D2f6TnnEdJkiRJ0vJnqrOq/gdwcpLHMH8dxz2Bx9Ks5yhJkiRJWk5Nqcexqs4E/ha4GHhRe7kQ2BVYfWkVJ0mSJEnq3uKs43g28Eq4bxmOVwPHA1sCKy6V6iRJkiRJnZvqOY4kWTHJi5KcBFwEvAD4ArDtUqpNkiRJkjQGFtnjmORhwGuBfYF5wDdp1m/cp6rOWbrlSZIkSZK6NrTHMclpwJnAusBLq2qbqnoPUKMoTpIkSZLUvUX1OP4t8FngsKqaNYJ6JEmSJEljZlHnOD6OJlyenuT3Sd6WZOMR1CVJkiRJGhNDg2NV/b6q/hHYBDgUeD5wWXu75yZZd+mXKEmSJEnq0lTXcby9qo6qqqcAjwA+BrwNuDrJD5dmgZIkSZKkbk15OY4JVXV+Vf07sDnwUuDOJV6VJEmSJGlsLHZwnFBV91TV96tqr6neJsl6SY5PMi/JJUn2HrLvY5OcmmRukmuSvLVt3zDJ0UmuTDInyRlJHt9zuycnube93cRlv/v7OCVJkiRpulvkOo5L2Gdpeig3AnYETkpydv+MrUk2AH5EMxz2WGAVYLN285rAb4EDgGuB17TH2aqq5rb7XFlVmyFJkiRJesDud4/j4kqyBvBi4MCqmltVpwMnAPsM2P0A4MdV9Y2quqOqbqmqcwGq6sKqOrSqrmp7PQ+jCZYPG9VjkSRJkqTpZGTBEdgOuLuqzutpOxvYfsC+uwI3JPllkmuTnJhki0EHTbIjTXA8v6d5w3Z460VJPtmGVkmSJEnS/TDK4LgmcHNf2xxgrQH7bgbsB7wV2AK4CDi6f6ckM4CjgIOrak7b/BeaYbCbAHsCf0OzlMhCkrw+yVlJzpo9e/biPh5JkiRJmhZGGRznAjP62mYAtwzY9zbg+Kr6bVXdDhwMPCHJ2hM7JFkNOBE4s6o+NNFeVVdX1TlVdW9VXQS8g2aI7EKq6rCq2rmqdp45c+YDenCSJEmStLwaZXA8D1gpyUN72nYAZg3Y949A9fzee50kqwLfAy4H3rCI+y1G+zglSZIkabkyskBVVfOA44BDkqyRZDdgL5qhpv2+CrwwyY5JVgYOBE6vqjnt78fS9EruV1X39t4wyVOSbJnG5sCHge8vxYcmSZIkScu1UffEvRlYjWYZjaOBN1XVrCS7J5lYSoOqOhl4N3BSu++2wMSaj08A/g54BnBTz1qNu7fbdwJ+Ccxrf/4JeMtSf2SSJEmStJwa6TqOVXUD8IIB7afRTJ7T2/Z54PMD9j0FyJD7OJRJJsORJEmSJC0+z/2TJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDTXS4JhkvSTHJ5mX5JIkew/Z97FJTk0yN8k1Sd7as22rJD9PcmuSvyR5Wt9t35bk6iQ3Jzk8yapL83FJkiRJ0vJs1D2OnwXuBDYCXgl8Psn2/Tsl2QD4EfBFYH1gW+AnPbscDfy+3fYfwLFJZra3fSbw78BTgS2BbYCDl9LjkSRJkqTl3siCY5I1gBcDB1bV3Ko6HTgB2GfA7gcAP66qb1TVHVV1S1Wd2x5nO+CxwHur6raq+i7wp/bYAPsBX6mqWVV1I/A+YP+l+uAkSZIkaTk2yh7H7YC7q+q8nrazgYV6HIFdgRuS/DLJtUlOTLJFu2174MKqumWS42zf/t67baMk6y+RRyFJkiRJ08wog+OawM19bXOAtQbsuxlNz+FbgS2Ai2iGp04cZ86Q4/Rvn7i+0P0keX2Ss5KcNXv27Ck+DEmSJEmaXkYZHOcCM/raZgC3DNj3NuD4qvptVd1Oc47iE5KsPYXj9G+fuL7Q/VTVYVW1c1XtPHPmzMV6MJIkSZI0XYwyOJ4HrJTkoT1tOwCzBuz7R6B6fu+9PgvYJklvD2LvcWa1v/duu6aqrr+/hUuSJEnSdDay4FhV84DjgEOSrJFkN2Av4KgBu38VeGGSHZOsDBwInF5Vc9pzJP8AvDfJg5K8EHgM8N32tkcCr0nyyCTrAO8BvrYUH5okSZIkLddGvRzHm4HVgGtpzll8U1XNSrJ7krkTO1XVycC7gZPafbcFetd8fDmwM3Aj8GHgJVU1u73tj4CPAj8HLgUuAd67lB+XJEmSJC23VhrlnVXVDcALBrSfRjOpTW/b54HPT3Kci4EnD7mfQ4FD73+lkiRJkqQJo+5xlCRJkiQtYwyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShDI6SJEmSpKEMjpIkSZKkoQyOkiRJkqShRhock6yX5Pgk85JckmTvSfY7KMldSeb2XLZpt+3e1z43SSV5cbt9/yT39G1/8ugepSRJkiQtX1Ya8f19FrgT2AjYETgpydlVNWvAvt+qqlf1N1bVacCaE7+3ofBE4Ec9u/2qqp645MqWJEmSpOlrZD2OSdYAXgwcWFVzq+p04ARgnwd46P2AY6tq3gOtUZIkSZK0sFEOVd0OuLuqzutpOxvYfpL9n5fkhiSzkrxp0A5tGH0JcETfpp2SXJfkvCQHJhl1z6okSZIkLTdGGajWBG7ua5sDrDVg328DhwHXAI8Hvpvkpqo6um+/FwHXAaf0tJ0KPAq4hCaUfgu4G/hQ/50keT3weoAttthiMR+OJEmSJE0Po+xxnAvM6GubAdzSv2NVnVNVV1bVPVX1S+BTND2L/fYDjqyq6rnthVV1UVXdW1V/Ag6Z5LZU1WFVtXNV7Txz5sz7+bAkSZIkafk2yuB4HrBSkof2tO0ADJoYp18B6W1IsjnwZODIxb2tJEmSJGnqRhYc28lrjgMOSbJGkt2AvYCj+vdNsleSddPYBXgL8P2+3fYBfllVF/Td9tlJNmqvPxw4cMBtJUmSJElTNNJ1HIE3A6sB1wJHA2+qqlkTazP27Pdy4HyaYaxHAh+pqv4JcPZl4UlxAJ4K/DHJPOC/acLqB5fsw5AkSZKk6WOks41W1Q3ACwa0L7A2Y1W9YgrHevgk7W8H3n7/q5QkSZIk9Rp1j6MkSZIkaRljcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNZXCUJEmSJA1lcJQkSZIkDWVwlCRJkiQNNdLgmGS9JMcnmZfkkiR7T7LfQUnuSjK357JNz/ZqjzGx7cs925LkI0muby8fSZJRPD5JkiRJWh6tNOL7+yxwJ7ARsCNwUpKzq2rWgH2/VVWvGnKsHarq/AHtrwdeAOwAFPBT4CLgCw+gbkmSJEmatkbW45hkDeDFwIFVNbeqTgdOAPZZwne1H/CJqrq8qq4APgHsv4TvQ5IkSZKmjVTVaO4o2Qk4o6pW72l7O/Ckqnpe374HAW8D7gGuAj5TVZ/v2V5t+wrAL4EDquridtsc4BlV9ev2952Bn1fVWgNqej1NDyXAw4D/WyIPdnxsAFzXdRGalM/P+PM5Gm8+P+PP52j8+RyNN5+f8be8PUdbVtXMQRtGOVR1TeDmvrY5wEKBDvg2cBhwDfB44LtJbqqqo9vtTwLOBFYH3g/8IMmOVXV3ez9z+u5jzSSpvpRcVYe197NcSnJWVe3cdR0azOdn/PkcjTefn/HnczT+fI7Gm8/P+JtOz9EoJ8eZC8zoa5sB3NK/Y1WdU1VXVtU9VfVL4FPAS3q2n1pVd1bVTcBbga2BR0xyPzOAuf2hUZIkSZI0NaMMjucBKyV5aE/bDsCgiXH6FTBsZtTe7bPa4y7ufUiSJEmSBhhZcKyqecBxwCFJ1kiyG7AXcFT/vkn2SrJuu7TGLsBbgO+327ZPsmOSFZOsSTP5zRXAue3NjwQOSLJpkgcD/wp8bWk/vjG13A7DXU74/Iw/n6Px5vMz/nyOxp/P0Xjz+Rl/0+Y5GtnkONCs4wgcDjwduB7496r6ZpLdgR9W1ZrtfkcDzwBWBS4HPldVn2637Ql8HtgMmEczOc6/VdVf2+0BPgK8tr3bLwPvdKiqJEmSJN0/Iw2OkiRJkqRlzyjPcZQkSZIkLYMMjpIkSZKkoQyOkgS0E25dkGTVrmuRllVJ/Fwxxtq/c0f4d066f9r30CHT9T3kOY7SiCRZEfgZ8MyquqPrerSwJOcBj6uqOV3XooUlOYpm+aV+d9BMpPa9qjp7tFVpQvs3bi6wjn/jxleSq4AtququrmvRwvysMP6SXAdsWFX3dl3LqPnN4HImycpJdk/ysvb3NZKs0XVdgqq6B9ga33fj7D+Bbyd5UpKHJNlm4tJ1YQJgDs0yTqEJigGeD9wDPAL4VZJ9uytvemv/xp0HrN91LRrqk8DBSVbuuhAtzM8Ky4QjgTd2XUQX7HFcjiR5NHACzbfvm1XVmkmeA+xXVS/rtjoBJPkHYA/gvTQffO97A07Hb67GTZLJnoOqqhVHWowWkuQnwMFVdUZP298Ch1TV05M8C/jPqnp4Z0VOc0neAbwc+BQL/407uau6NF+Sy4CNab5wmc2Cz9EWXdWl+fysMN6SnA48nmYd+ctY8PnZo6u6RsHguBxpX8hfrKqjktxYVeu2vY3nVdWmXdenBYJJ7xsvGEykRUoyB1i/qu7uaVsZuK6q1m7X8b1lYk1gjV6SiybZVFVlz/0YSPKkybZV1SmjrEWD+VlhvCXZb7JtVXXEKGsZNYPjciTJjcB6VVVJbqiq9dr2+66rW0m2nGxbVV0yylo0uSRbAJsCl1fVZV3Xo0aSU4AzgfdW1e1JHgQcBDyhqvZohxT/wl4TScsyPyuMtyQrtkOKpx3HTy9fLgb+prchyS7A+Z1Uo0HWrapLBl26LkyQZJM2nJwPHAdckOTUJA/uuDQ19gN2B25OcjVwM81wrolvf9cD3txRbWolWSnJHkle0Z5zv1LXNWm+di6Eg5NcmOT29ufBSVbpujY1ej4XXAbcCVzmZ4WxcnWSzyXZretCRs3guHw5EDgpycHAKkneBXwHeE+3ZanHT5LMSvIeJ1wZS58HzqYJ+JsA6wK/B77QaVUCoKourqonAA+hmSRn26p6QlVd1G4/q6p+0GmR01yShwPnAt8E3gIcDfwlySM6LUy9Pgo8jWZyjx3an3sCH+myKM2XZEaSI4Hbac6ju61dRmXtjktT4xk0M0gfneSiJB9q5xlZ7jlUdTmTZCfgdcCWNN9UfamqftdtVZrQTrP9LOAVNLNBzqL5gPWtqrq2y9p03xTbm/ROU9+u1XRFVW3QXWXqlWRDYIHzGKvqwo7KUY8kJwM/BD5e7QeMJG8HnltVT+m0OAGQ5HJgh6q6vqdtA+Bs50MYD0m+BqwFvAu4hOYz3QeAW6tq0vPrNHrtOcOvAF4MXFVVj+m4pKXK4Ch1JMlqNL0mbwJ2rappuZjsOEnyV+AlvWsBJnkMcFxVbdtdZQJoZ039CrBJ3yYnjBgTSW4AZvae/9MOVZ1dVet2V5kmJLkCeMyA4PjHqnJY/hhoh+JvU1W39rStCVxQVRt1V5n6JdmIZibpfYGHVtWMjktaqjzvYDmS5JBJNk0sjv2jqrpmhCVpEu2kHn8HvAzYGTit24rU+ijwP0m+wvxveV9NMwxc3fss8D7giKq6retiNNCVwJOA3qU3dm/bNR6+A5zYntZyKc3fufcA3+60KvW6HZhJ8//QhA1oPs+pY0nWoelh3BvYFfgJzVDvEzosayTscVyOJDkGeCHwG5phqpsDuwAnApsBjwZeXFU/6qzIaa5dV3NvmmGq5wDHAMdU1dWdFqb7JNmT5jl6MM2H3aOr6mfdViW4rzdr/fI/rrGV5Pk0w+9/QPOhdyvgOcCrqur7HZamVjsJznvo+zsHvL+qDCZjIMl7aHqwDmX+l5hvA46qqvd3WZsgya3AL2neN9+tqpu6rWh0DI7LkSTfpvmQe3xP217A3lX1snbdmbdV1Y5d1TjdJTmH5g/NN6vqgq7rkZYlST4GnFtVh3ddiyaXZDvgpcwPJd+uqvO6rUpadrRr0r6ahcP94X5x1r0kewNnVtWFSTam6W28F3jX8t4RYHBcjrSLY6/Xd27JisCNVTWj93pnRUpjLMkBwMlV9Yckj6cZ0nUPzZcvv+q2OiU5jWYUxSXAAv85V9UenRSlodpzue+1J2t8JHkKcHFVXTTdPvRKS0KSc4FnVtWlSb7ZNt9Gc3738zssbakzOC5HkvwvzbdRn+lp+0fgtVW1U3sC79lVtXFnRU5zfcFkV5pzSgwmYyLJZcCjqmpOkp8D3wduAV5fVY/vtjq1oyYGqqojRlmLBkvycZoext8keS5wLFDAy6rqxG6rE0zvD73LiiSvAP5QVee2Pfhfogn3b6qqv3RbnZLc3HbIrARcQzOU+E7gyuV9BnaD43IkyWNpFi1fkWbdn01pQsmLqup/k+wBPKyqvtRhmdOawWS89fxnsBZNr9bMqronyU1VtU7H5UljL8lVwEOq6tYkv6aZcGoO8MmqmhbrnI276fyhd1mR5ALgCVV1TZITgf+jWTdwj6ras9vq1C5p8zfAo4CDqmr39tzh2VW1XK+16ayqy5E2HD4U+Fua6eqvAn41sSZdVZ0KnNphiYK129C4Fs3Cy09rg8knui5MAFyW5AnA9sCp7XMzg+YLGHUgyT5VdVR7/R8m28/zHsfG6m1oXJ9mOYHvAiTZsuO6NN/N7QikRwHnVNXc9kPvyh3XpflmtqHxQcATgZcAdwHXdVuWWv8F/BZYBfiXtm03YLnvDTY4LmfakGg4HF8Gk/H2bzRD6+6kmWobmmVTftNZRXoFcFR7fZ9J9inA4DgezkvySmBb4Kdw3xqBLp8yPqbth95lyOwk29LMhv/bqrojyepAOq5LQFV9JMnxwD09Ex1eAby2w7JGwqGqy7h26OMin8Sq2mIE5WgRkjybZgHzO2mWRvldOzvXPlX17G6r0yBJVob7vpSRNESSxwGfovkb95qquqANks+qqsmCv0asPW/uvg+97e+rVtWfuq1MAEn2p3kf3UNzfvBP26VuDqiqJ3dZm6Y3g+MyLsmTen59HLAf8Gnmr/vzT8CRVeVQyI4lWQF4MnBG7wyDBpPxkeSRwPXtEKE1aXog7wU+VlW3dludkvy+qnYa0H5WVe3cRU3Ssq6dZfXeqjql61o0X9vDyMT/PUk2BFZw5lt1yeC4HEnyZ5qZ0q7oadsM+FFVPaq7yjQhyS1VtVbXdWiwJGcDL62q/0vyBeBhwO3AdfaWdG/Q+6dd7+z6qlqvo7LUo2+ph02AD+NSD2MlySnAu6vqjCTvBA4A7gY+W1Uf7LY6ASSZCdzWnn+6IrAvzfvoqKq6t9vqNJ0ZHJcjSW4Atq6qOT1t6wAXVdW6nRWm+yQ5CXhfVZ3ZdS1aWJI5VbV2G0auAR5Jc27WRVW1YbfVTV9Jjmyvvgz4Vt/mrWj+L9t9pEVpIJd6GH9Jrgc2bM+xPx94Ps3s3md4Wst4aGckfmNV/T7Jh4Hn0UyO8/Oqelu31Wk6c3Kc5csJwAlJ3g9cDmwOvKtt13i4BPhhku8DC5yfWlX/r7OqNOH2dsbbRwKXVtV17ZT1D+q4runugkmuF3AG8J3RlqMhNm1D40rAM+lZ6qHbstRjBaCSPITmS5dzAJL4BfP42A74Q3v9VcATaJbjmAUYHNUZg+Py5Y3AQcAXgAfTLMfxbeDgDmvSglYDvtde36zDOjTYN4GTgbWAz7RtjwUu6qwiUVUHAyQ5s6p+3HU9GsqlHsbf6TR/3zYBjgdoQ6RLPYyPe4BV2kmL5rRfxqwArNlxXZrmHKoqST2SPAO4q6p+3v6+MzCjqk7utjIBJHkyzfk+m9JMf37UxHOl7rXnzP0j7VIPVXVMe97jh6vq8d1WJ4B2jc1/pRn6+LE23D8XeGhV/WenxQmAJEcBM4D1gR9X1fuSPAo4tqoe3m11ms4Mjsu4JHtU1ant9T0n288PveOlHQ65AT1rMlXVhd1VpF5JNqcZcue5qGMkyWuBDwJfphn2vQXwGuDAqvpSl7VpPpd6kB6YJKvSzJJ/F82XY3e3X5ptXFXHdFmbpjeD4zIuyZ8nZkxt13S8e8BuVVXbjLYyDdIu9/ANYAea87PS/qSqVuywNAFJtgCOBnaked+smeQlNGvQLfcL+467JOcBf19VZ/e0PQb4blU9tLvK1KtdYmhX4MFV9a0kawBU1bxuKxPcF0r+H/AKYP12QrBnANtV1WeG31qj1A5P3aiqruq6FgmaE6S1DOsJjSsCM4GHV9XWfRdD4/j4HPBzYD3gZmBd4Is03yyqe18ETqI5x3FiXc2fAk/vrCL1Wh84p6/t/2jeTxoDSR4NnAd8CfhK2/wk4PDOilK/T9Kcg/pK5k/QNgt4U2cVaQFJ1mlnJb4dOL9te347+aHUGXsclyPtGnTPripnrxtTSW6kmQb9riQ3VdU67bfxf66qrbuub7prp6mfWVX3JrlhYm3Aieeq2+qU5ASaIarvrKpb2/fOh2iWIXpet9UJIMnpwBer6qgkN1bVuu3zdF5Vbdp1fYIkVwHbVtU8/86NpyTHADcCh9BMMrVuu7bjLx1doS45q+ry5RvAD5J8imY5jt6lHjzHcTzcTjO74F3Ade3QyBtpelLUvWuAbWl6TID7hhdf2llF6vUG4BiamTuvp+lp/CXNkDuNh+2Br7fXJ4bhz0uyWnclqc+d9H3+a0PJ9d2UowGeSjPU+64kE++j2UlcT1idMjguXyaGmRzU116Aw1XHw2nAS4GvAccCPwTuoFkCQt37OM2XLx8CVkryCuDdwIe7LUutdwL/RrMm4IOBK6vq8m5LUp+Lgb8BzppoSLIL7XA7jYXvAEckeRtAkk2A/6T5UkbjYQ7NBHr3ndvYftHsuY7qlMFxOeJQx/FXVS/t+fXdwJ9pzqc7spuK1KuqDm97st4AXEaz7MOBVfW9TgvThNCsgzqPZs3Nb3RajQY5EDgpyRdo1qF7F80aw6/rtiz1eDfwEeBPwOrAX2nOSXXN5/HxZeC7Sf4DWCHJ39LMKP2FbsvSdOc5jlIHnClt/LQTTP0MeGZV3dF1PRqsfe88lWZ46guBC4FvVNWhnRam+yTZiSYobknzBcyXqup33VYluO/v3HuBD1TVHe0Q1evKD4NjJUmAt9B8ibklzekSXwQ+5XOlLhkcpRFKsi7wWeAlNIvMr5Hk+cAuVfWebqtTkktoZia+retatGhJNgW+CjzV5Wy614aS84BH+uXL+EpyHc0kbfd2XYsW1r6PDgde7/tI48blOKTR+jzNuQtb0kxQAPAr4GWdVaReBwOfT7JlkhWTrDBx6bowNZKskeRVSU6iCSl343I2Y6Gq7gHuAR7UdS0a6kia4cMaQ+376BmAwV5jxx5HaYSSzGb+TGm906DPqaq1Oy5v2ksy8R917x/GAGWPVveSfAd4NvC/wNHAd6rqum6rUq8kbwb2ojkfq3927wu7qkvztUumPB64gmYoce9ztEdXdWm+JO8A1gEOqqo7F7G7NDIGR2mEkpwP7F5VV00Ex3amtJ9U1cO7rm+6S7LlZNuq6pJR1qKFtR+mjqkql0cZUz1fvvTzy5cxkWTSHvqqOmKUtWiwJJcBG9P04M9mwXC/RVd1SQZHaYSS/DvwfOA/gONpek8+CHy/qv6zw9IkSdIYSPKkybZV1SmjrEXqZXCURsiZ0sZbkqNYcJjqhDtoht19r6rOHm1VkrTkJPmHSTZN/J0700lZJA1icJSkVpLPAPsAJ9Cc+7M58DyahbHXoektfmNVue6mNECS0xj+5ctxVXXiaKtSryS/AP4WuIbmOdkM2Ag4C9iq3W2vqjqri/oESQ6ZZNPE++hHVXXNCEuSAFip6wKk6SbJw4AdgDV726vq8G4qUo/tgOdU1RkTDe3Cy4dU1dOTPAv4T5pZCSUt7Bc0s9wewfwvX/YFvkkz0dThST5WVR/trELNognwn55oSPJPwMOBJ9KcSvFfNOFS3diOZp3a3zD/fbQLcCLNl5mfS/LiqvpRdyVqOrLHURqhJO8G/h9wNnBrz6aqqj27qUoTkswB1q+qu3vaVqZZIHvtdqjxLVW15qQHkaaxJL8G9q+qc3vaHg4cUVWPT7ILcHRVPaSzIqe5JDfS/J27t6dtRZq/c+smWRW41pm+u5Pk2zTvk+N72vYC9q6ql7UTHL2tqnbsqkZNTwZHaYSSXAs8rar+2HUtWliSU4AzgfdW1e1JHgQcBDyhqvZIsg3wC2e1kwZrv3zZsPccuSSrAVdV1Trt73P98qU7Sf4CvLOqvt/T9nzgY1X1sCRrAxdU1QadFTnNte+j9do1HSfaVgRurKoZvdc7K1LTkotaS6N1G/CXrovQpPYDdgduTnI1cDOwB/MXmF8PeHNHtUnLglOBrybZNsmDkmwLfAk4HSDJo4GruixQvAU4MskZSY5JcgZwFPDP7fbH0wxVVXcuAN7U1/bGth1gAxYctSSNhD2O0ggl2RfYjaYXa4ET23uHDalbSTYHHkzTS+KagdIUJVkP+BzwIpp5FO4CjgP+uaqua8/xXsuJV7qVZAOa5aAeTBPkT6qq67utShOSPJbmfbMicAWwKc2aji+qqv9NsgfwsKr6UodlahoyOEoj1LM4du8bL7g49thIsj7wHGCTqvpokgcDK1TV5R2XJi0zkqwAzARm+6XYeGq/INu0qs7suhYtrD2/flfmh/tfVdVd3Val6c5ZVaXR2rrrAjS5dtHl79JMS78b8FHgocDbaWayk7QI7WQ4fw9sVFX/1PYyruq53eMhyRbA0cCONF9irpnkJcCzquq1Xdamwarq1CRrJFmlquZ1XY+mL89xlEaoqi6Z7NJ1bQKapTZeVlXPAiZmVv01zTTokhYhyd8Dp9EMrdu3bV4LOLSzotTvi8BJNM/LRA/WT4Gnd1aRFtCeC3wezfnBX2mbnwS4bJc65VBVaSlLclhVvb69fhSDF8emqvYd1K7RSXJjVa3bXr+hqtZrh9zNrqr1Oy5PGntJzgVeXlVnT7yf2iF3V1bVzK7rEyS5HphZVfdO/J1r22+amPlW3UpyOvDFqjqq5320BnBeVW3adX2avhyqKi19F/VcP7+zKjQV5yR5ZlX9uKftacCfuipIWsZsCEwMSa2en35LPT6uAbal6dECIMkjAScCGx/bA19vrxdAVc1rl7aROmNwlJa+XyfZs71+WqeVaFH+FfhBkpOA1ZJ8kebcxr26LUtaZvwO2Ac4sqft5cBvuilHA3yc5u/ch4CVkrwCeDfw4W7LUo+Lgb+hOd8egCS74JfP6phDVaWlLMlFi96LqqptlnoxGqodlrox8CpgS+Ay4OvOqCpNTTsxzk9oRlrsCvwC2A54RlX9tcPS1CPJXsAbaP7OXUozLPJ7nRal+yT5O5pzG79A84XmB2jWcXxdVf2ky9o0vRkcJQlIsiIwF1inqu7ouh5pWZMkNDNHXwc8i/lfvvygquZ2WZsa7d+5nwHP9O/ceEuyE/A65r+PvlRVv+u2Kk13BkdJaiU5G3h2VV3ZdS3SsijJPGAt124cX0kuAR5eVbd1XYsW1ob784BHGu41bjzHUZLm+wbNuT+fAi6nZ0KPqjq5s6qkZcfvaYam/qXrQjSpg4HPJ3kvC/+dM/B3rKruSXIP8CDA4KixYo+jJLWGnI/qOajSFCR5P805wl+jGV7XG0pcg24MJJkIh70fAEPzd27FDkpSnyRvppmU7YMsHO4v7KouyeAoSZKWiCQ/n2RTVdWek2zTCCXZcrJtVXXJKGvRYD3hvp/hXp0yOEpSK8n3q2qhpTeSHFdVL+qiJkmSpHFgcJSkVpKbq2rGgPYbqmq9LmqSliVJZgK3VdXcdpKPfYF7aJa18fy5MZDkKBYcpjrhDpphkd+rqrNHW5WkZYGT40ia9pIc0l5dpef6hG0Ah29JU/MDmvXmfk9zftbfAXcBOwFv67AuzTcH2Ac4geY81M2B5wHHAI8A3pnkjVV1ZHclTm9JTmN4uD+uqk4cbVUSrNB1AZI0BjZvLyv0XN8c2Izmg9Xfd1eatEzZDvhDe/2VwLOBPYGXd1WQFrId8Jyq2qeq3l1V+9A8Tw+pqpcDLwLe3WmF+gWwFXAK8PX255bAWcA1wOFJ3tFVcZq+HKoqSa0kr6uqL3Vdh7SsSnIdsClNODmmqrZPsgIwp6rW6rY6ASSZA6xfVXf3tK0MXFdVaycJcEtVrdlZkdNckl8D+1fVuT1tDweOqKrHJ9kFOLqqHtJZkZqW7HGUpPnOSLIRQJI1kxyc5L1JVu+6MGkZ8UPg28DnaYY+AjwSuKKzitTvD8AHkjwIoP35PmDivMatgRu6KU2thwP9y25cAjwMoKp+A2w06qIkg6MkzXc0sE57/ePAHsCuwBe7KkhaxrwWOAn4CvChtm0D4KCuCtJC9gN2B25OcjVwM83fuv3a7esBb+6oNjVOBb6aZNskD0qyLfAl4HSAJI8GruqyQE1PDlWVpFaSOT1Dta6h6Sm5Dbioqjbstjpp2dEOT92oqvxwO6aSbA48GLiqqi7tuh7Nl2Q94HM055uuCNwNHAf8c1Vdl+RhwFpVdVaHZWoaMjhKUivJNcC2NIHxs1W1c5KVgBsGLdMhaUFJ1qH5wPsS4K6qWiPJ84Fdquo9nRanBSTZEFjgPMaq6h8eqQ61X8DMBGa7nI3GgctxSNJ83wROBtYCPtO2PRa4qLOKpGXLF4AbaWaAPKdt+xXwCcDgOAaSPItmKPEmfZuKpndLYyDJ2jTnNK7Z/g5AVZ3cYVma5uxxlKQeSZ5B01Py8/b3nYEZ/mctLVqS2cCDq+quJDdU1Xpt+5yqWrvj8gQkuQD4GM0Mnbd1XY8WlmR/4LPAXODWnk1VVdt0UpSEwVGSFpJkC5olBa7w3B9p6pKcD+xeVVdNBMf2/fSTqnp41/UJktxAsxyHHwDHVJIrgNdW1Q+7rkXq5ayqktRKskmSU4C/0kxEcH6SU5I8uOPSpGXFl4HvJnkKsEKSvwWOoBnCqvHwFeDVXRehoVYCftJ1EVI/exwlqZXke8ClwLuqal6SNYAPAltX1fM7LU5aBrQzEr8FeAPNeY6X0ixn8yl7uMZDktOAXWjWBby6d1tV7dFJUVpAkgNozrV/n5PiaJwYHCWpleQ6YJOququnbVWaIasbdFeZJC0ZSfabbFtVHTHKWjRYksuAjYE7get7t1XVFp0UJeGsqpLU60aapTjO7ml7GHBTJ9VIy6AkTwdeDmxYVc9zgqnxYjhcJryq6wKkQQyOkjTfR4H/SfIVmmFcW9KcC3Rgp1VJy4gk/wy8leZcx5e0zbcBnwae0FVd012SfarqqPb6P0y2X1UdPrqqNJmqOqXrGqRBHKoqST2S7AnsDTwYuBI4uqp+1m1V0rKhXerhqVV1cZIbq2rdJCsC11bV+l3XN10l+e+qek57/eeT7FZVtecIy1KPJP9RVR9orx8y2X5V9f9GV5W0IHscJalHO5zOIXXS/bMWcFl7feKb6ZVpztVSRyZCY3v9KV3Woklt1nN9886qkIawx1GSWklWBt4D7MP8HsejgA9UlR98pUVIcizw+6r6QM86ju8AdqyqvbuuT5Dk91W104D2s6pq5y5qkrRsMDhKUivJJ2mmqT+Y+ec4HgicVVVv67I2aVmQZBPgRGADYFPgQuAW4O+q6upht9VoJLmlqtbqawtwfVWt11FZ6jHxpcuA9murasMuapLA4ChJ90lyObBDVV3f07YBcHZVbdpdZdL4S7IC8GTgV8Cjab54uQz4jWvRdS/Jke3VlwHf6tu8Fc1nwt1HWpQGmiTcrwxc7bnC6pLnOErSfFnMdkmtqro3yffbD7y/aS8aHxdMcr2AM4DvjLYc9UtyGs3z8aAkp/Zt3gz45eirkuYzOErSfN8BTkxyMHApTY/Je4Bvd1qVtOw4NcmuVXVm14VoQVV1MECSM6vqx13Xo4G+TPNF5eOAr/S0F3ANTtymjjlUVZJaSVahCYoLLMcBvL+q7uiyNmlZkORzwCuA79MMU73vQ4bLCIyHJE8BLq6qi5JsDHwEuBd4l+ehjockD6+qv3Rdh9TP4ChJkpaIJF+dbFtVvXqUtWiwJOcCz6yqS5N8s22+DZhZVc/vsDS1krwC+ENVnZvkYcBhNOH+TQZKdcngKEk9kuxJ02My0eN4TFX9rNuqJGnJSHJzVc1IshLN8MctadbZvLKqNui2OgEkuQB4QlVdk+RE4P+AucAeVbVnt9VpOluh6wIkaVwk+VfgGOAG4CTgeuCbbbukRUhywyTt1466Fk3q5iQbAU8CzqmquW37yh3WpAXNbEPjg4AnAv8BHALs2GlVmvacHEeS5jsA2LOq/jzRkOQo4KfAJzqrSlp2LBQ+2mUEVuygFg32X8BvgVWAf2nbdgMcAjk+ZifZlmZZm99W1R1JVscZvtUxg6MkLej8vt8vpGeCD0kLcxmBZUdVfSTJ8cA9VTWxLMcVwGs7LEsLeh/wO+AemnU3AZ4GnN1ZRRKe4yhpmmsXLZ/wGpoFzA8CLgc2Bw4ETqmqL4+8OGkZkWQ/mt6QzwNv7Nl03zICVXVXF7VpYe35jU8ANqUJjb+sqru7rUq92h5GqurW9vcNgRWc+VZdMjhKmtaS3Mv8HsXeYUC9bVVVDrWTFsFlBMZfkocDJwKr0SyZsjlwO/C8qjq3y9o0X5J1gecxP9z/oKoGnkMsjYrBUdK0lmTLqexXVZcs7Vqk5UE78couwAb0fBlTVYd3VpTuk+Rk4IfAx6v9EJjk7cBzq+opnRYnAJL8Lc0EbX8BLgG2AB5B8xz9qsvaNL0ZHCWpleTtVfXxAe0HVNWhXdQkLUuSvAD4OvBXYHtgFvAo4HRDyXhoZ76dWVX39LStBMyuqnW7q0wTkvwa+GRVHdPT9jLg7VX1uO4q03TnchySNN//m6T9PSOtQlp2vR94dVXtBMxrf76eZqIPjYcraZbi6LV7267xsB3w7b62Y4FtO6hFuo+zqkqa9pJMLKi8YpKnsOC5jtsAt4y+KmmZtEVVfaev7QjgauDtHdSjhb0bOCHJD2iGQW4JPBd4VadVqddfgZcD3+xp+3vggsG7S6PhUFVJ016Si9qrWwCX9mwqmg+8H66qE0ZemLSMSXI+sFu7ePnvgTcD1wFnVtX63VanCUm2A14KPJimp/HbVXVet1VpQpInAD8AzqMJ91sBDwX+rqpc2kadMThKUivJkVW1b9d1SMuqJO8Ezq+q7ybZFzgMuBf4RFUd2G116tUuRbQRcE1V3dt1PVpQO6vqc5kf7v/bWVXVNYOjJElaIpKs0BtCkmwBrOEyD+MjyQzgMzQLy68E3A0cA7ylquZ0WZsW1L5/NgWuqKpLF7W/tLQ5OY4ktZLMSHJokt8luSTJpROXrmuTxl2SFYF5SVadaKuqSw2NY+fTwBrAo4HVe35+usuiNF+STZKcQnOu43HA+UlOTfLgjkvTNGdwlKT5Pgc8FjgEWA/4Z5pzHj/ZZVHSsqBd3uE8wHMZx9uzgH2q6ryquqM9t/HVbbvGw+eBs4H1qmoTYF3g98AXOq1K055DVSWpleRa4BFVdX2Sm6pqnSSbAidW1WO7rk8ad0neQTMb5KeAy2kmmAKgqk7uqi7Nl+Ri4ElVdUlP21bAqVW1RVd1ab4k1wGbVNVdPW2r0gxZ3aC7yjTduRyHJM23AjBxjs/cJGsDV+HaWdJUvan9eVBfe9EsbaPufRn4aZJDmb8cx9toJjLSeLgReCRNr+OEhwE3dVKN1DI4StJ8Z9MsjP0z4DSaoatzaYbfSVqEqtq66xq0SB+gmaVzb+bP2PlR4PAui9ICPgr8T5KvMD/cvxpwZmJ1yqGqktRKsg1AVV2YZEPgg8CawMFO8CEtWpLvV9VeA9qPq6oXdVGTtCxKsicLhvujq+pn3Val6c7gKEmtJJ8GjuldYLldiPmlVfUvnRUmLSOS3FxVMwa031BV63VRkxaW5B+AVzA/lBwDHF5+KJQ0hMFRklpJZgObVtWdPW2rApdV1YbdVSaNtySHtFffQTPMrtc2wPZVtdNoq9IgST4K7AX8J/OHQb6FZhKwd3RYmlpJVgHew8Lh/gNVdXuXtWl68xxHSZqvWHiZohUHtEla0ObtzxV6rkPznrqMhSfLUXf2Bx5bVZdPNCT5AfC/NMFf3fs8zWQ4b2F+uH83sCnwDx3WpWnOHkdJaiX5LnAR8I6qujfJCsCHgYdW1Qu7rU4af0leV1Vf6roOTS7JBTTBcU5P2zrA76rqIZ0VpvskuR54SFXd1NO2HnC+Q77VJXscJWm+twI/AK5KcgmwBc1yHM/rtCpp2XFbf0OSAP9eVR/qoB4xf+Kv1n8CxyX5MM1am5sD/wZ8soPSNNjVwOosuPzGajT/H0mdscdRknq0vYy70HyYugz4TVXd221V0rIhyV9phjy+sapubAPLUcC9VbV7t9VNX0nupRk2nCG7VVWtOKKS1KedRXXCLjQzqv4X88P9PwLfrKqPdFCeBBgcJUnSEpJkDZoerWcBXwPeDHwc+IhfwEiTS3LRFHarqtpm0btJS4fBUZIkLTFJZgI/Ax4FHAH8g8s8jI8kn66qtwxo/0+XHZI0jDMFSpKkJSLJc4GzgZ8Dj6GZGfK0JFt3Wph67T9J+z6jLEKTS/L9SdqPG3UtUi8nx5EkSUvKF4B9q+p/AJI8EfgP4Cxg/S4Lm+6STCzjsFLP9QnbANeNuCRN7imTtD95lEVI/QyOkiRpSXkMsHOSrwAbVtXzkvwQuKPjujS/R3EVFuxdLOAaYL+RV6QFJDmkvbpKz/UJ29Cs6Sh1xuAoSZKWlFcC/wJ8GXhJ23Yb8ALgo92UJICqegpAkvdX1Xu6rkcDbd7+XKHnOjTh/jLgoFEXJPVychxJkrREtIvLP7WqLk5yY1Wtm2RF4NqqcqjqGEmyIbBmb1tVXdhROeqR5HVV9aWu65D62eMoSZKWlLVoekag6SUBWBm4s5ty1C/JM4HDgU36NhXgOo5joKq+lGRtmsml+sP9yd1UJRkcJUnSknMq8O/AB3ra3kIzy6rGw+eA9wFHVNVtXRejhSXZH/gsMBe4tWdT0ZzrKHXCoaqSJGmJSLIJcCKwAbApcCFwC/B3VXV1l7WpkeQGYH3X1hxfSa4AXltVP+y6FqmXwVGSJC0xSQI8DtiSZtjqb6rq3m6r0oQkHwPOrarDu65FgyW5BnhwVd3TdS1SL4OjJEnSNJHkNGAXmqUdFugFrqo9OilKC0hyAM35wu/zSxeNE4OjJEnSNJFk0vUaq+qIUdaiwZJcBmxMM6nU9b3bqmqLToqSMDhKkiRJYyPJkybbVlWnjLIWqZfBUZIkaZpoz0F9LfAKYIOqekySPYCNq+rb3VYnaZyt0HUBkiRJGplDgNcAhwETwx4vB97ZWUVaQJJVk3wgyYVJ5rRtz0jyT13XpunNHkdJkqRpoj1/bqequi7JjVW1btsLeUNVrdt1fYIkn6NZzubDwA+rap0kmwI/qartu61O09lKXRcgSZKkkVmRZmF5aBaUB1izp03deyGwbVXNS3IvQFVd0YZHqTMOVZUkSZo+/hs4NMmqcN85j+8DTuy0KvW6k77OnSQz6ZthVRo1g6MkSdL0cQCwCTAHWJump3FLPMdxnHwHOCLJ1gBJNgE+AxzTaVWa9jzHUZIkaZpJshHN5DiXVdXVXdej+ZKsAnwEeB2wOnAr8CXgnVV1Z5e1aXozOEqSJC3HkqTaD3xJJh1tVlX3jq4qTUU7RPW68gO7xoDBUZIkaTmW5OaqmtFev5f5k+LctwtQVbXiyIsTAEm2qqqL2+vbTLZfVV04sqKkPs6qKkmStHzrXcJh686q0DB/AtZqr59PE+7Tt0/RzIordcIeR0mSJEnSUPY4SpIkLceSHMXCw1MXUlX7jqAcScsog6MkSdLy7fye6xsA+9Gs23gJzcyqzwOO6KAutZKcxtTC/R4jKEcayOAoSZK0HKuqgyeuJ/kx8NyqOq2n7YnAgV3Upvt8uef6Q4B/oAnzE+F+P+DwDuqS7uM5jpIkSdNEkjnABlV1V0/bysD1EzOvqltJzgReU1WzetoeCRxeVbt2V5mmu0nX8pEkSdJy5/fAB5OsBtD+/ADwhy6L0gIeAVzQ13YR8PAOapHuY3CUJEmaPvYHdgPmJLkGmAM8EXBinPFxCvC1JA9NslqS7YCvAKct4nbSUuVQVUmSpGkmyRbAJsBVVXVp1/VoviTrAZ8DXkSzbuPdwHHAP1fVdV3WpunN4ChJkjQNJQk9i8xX1b0dlqM+SVYAZgKzfW40DhyqKkmSNE0keXCS45NcT9OTdVfPReNlDWB1YKsk2yTZpuuCNL0ZHCVJkqaPLwJ3Ak8F5gKPBU4A3thlUZovySOT/J7m/NPz28tf24vUGYeqSpIkTRNtT+MWVTUvyU1VtU57Tt0vq8pZO8dAkl8A/wscQjOb6lbAh2ieo693V5mmO4OjJEnSNJHkWmDzqrojycXA44Cbgeuqaq1OixMASW4ENqyqu3rC/RrAn6tq667r0/TlUFVJkqTp49fAc9rrPwa+RTNj51mdVaR+twMrt9eva2fAXQFYv7uSJIOjJEnSdLIPzTqBAP8CnAz8Gdi7q4K0kNOAl7bXjwV+SPOcndxZRRIOVZUkSZoWkqwIHA68vqru6LoeLVq7JMfewFrAkVU1r+OSNI0ZHCVJkqaJJFfRTI7j8htjqA33PwOeabjXuHGoqiRJ0vTxSeDgJCsvck+NXFXdA2yNn9E1huxxlCRJmiaSXAZsDNwDzAYKCFBVtUWXtamR5B+APYD3ApfTPEcAVNW9XdUlGRwlSZKmiSRPmmxbVZ0y2TaNTpKJcNj7IX0i3K/YQUkSACt1XYAkSZJG5qmTtN+RZCvgR1V1zQjr0cJcq1FjyR5HSZKkaSLJMcALgd8AlwGbA7sAJwKbAY8GXlxVP+qsSEljyR5HSZKk6WMF4OVVdfxEQ5K9gL2ratck+wEfBgyOHUlyFAsOU51wB805j9+rqrNHW5XkjE2SJEnTyTOBE/rafgA8u73+dWCbkVakfnOAvWjOa7y8/fl8mgmNHgH8Ksm+3ZWn6coeR0mSpOnjAuBNwGd62t7YtgNsANw66qK0gO2A51TVGRMNSf4WOKSqnp7kWcB/Akd2VJ+mKc9xlCRJmiaSPBY4DlgRuALYlKYn60VV9b9J9gAeVlVf6rDMaS3JHGD9qrq7p21l4LqqWjtJgFuqas3OitS0ZHCUJEmaRtoQsivwYOAq4FdVdVe3VWlCklOAM4H3VtXtSR4EHAQ8oar2SLIN8AvX3dSoGRwlSZKkMZFka+AbwM7ADcB6wFnAq6rqwiQ7AxtX1Q86LFPTkMFRkiRJGjNJNqftFa6qS7uuRzI4SpIkSWMiye+raqcB7WdV1c5d1CSBy3FIkiRJ42Tb/oZ2QhyXSVGnXI5DkiRJ6liSieU1Vum5PmErYNZoK5IWZHCUJEmSunfBJNcLOAP4zmjLkRbkOY6SJEnSmEjyzKr6cdd1SP08x1GSJEkaH3e2S3KQZOMkRyT5apKNuy5M05vBUZIkSRofnwPuaa8fCqwM3Asc1llFEg5VlSRJksZGkpurakaSlYBrgC2BO4Erq2qDbqvTdObkOJIkSdL4uDnJRsCjgHOqam6SVWh6HqXOGBwlSZKk8fFfwG+BVYB/adt2A/7SVUESOFRVkiRJGitJtgPuqaoLen5ftar+1G1lms4MjpIkSZKkoRyqKkmSJHUoyblV9Yj2+mXAwJ6dqtpipIVJPQyOkiRJUrde13P9VZ1VIQ3hUFVJkiRpTLQzqO4P7Ais2butqvbtoCQJsMdRkiRJGidHADsAJ9Ks4yiNBXscJUmSpDGR5EZg66q6qetapF4rdF2AJEmSpPtcCqzadRFSP3scJUmSpA4l2bPn152Avwc+Rd9Q1ao6eZR1Sb0MjpIkSVKHklw0hd2qqrZZ6sVIkzA4SpIkSZKG8hxHSZIkSdJQBkdJkiRJ0lAGR0mSJEnSUAZHSZIkSdJQBkdJkiRJ0lD/H/9xEOxZ3vkBAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-02-16 00:49:24,632 - matplotlib.legend - WARNING - No handles with labels found to put in legend.\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3sAAAJwCAYAAAAwfXiUAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABXKUlEQVR4nO3dd5hkZZ238fsLDChJ0oCARBHBHBDTCuYsrjkj5rCuq+6uvmYwrWlddc2IChgQs+CaViWYxcCqgAiSBSTnJPzeP57TMzVN93QDM3VqTt+f6+qrq59zuurXXV3V9a0npaqQJEmSJA3Lan0XIEmSJEla8Qx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYk9SrJHslqST3v5Hff//u+/daoYUtAEn27n532y7E219Ikjwgyc+TXOLjZfLM9Fi4oc+NSU5OcthKqu+wJCevjOuWtHIZ9qQFbCQoVZIPzXLOpkmu7s45bMwlSrNKskH3Ivn+fdcyyZJsCHwVWAf4V+BZwBG9FqWJk+QVvgkgDc8afRcgaSJcCTw9yb9W1VXTjj0LCPD38ZclLdcGwJu7y4f1V8bEuwftd/W8qvpqz7Vo/g4EDgKuHtPtvQI4GfjMDMceSvs/IGkVY8+eJICvARsCj53h2HOA/wGmh0BJc0iy3o05tqJuo3PL7vP5K+L2Rm539SRrr8jrHLnuJFl3ZVz3qqKqrq2qK6vqugmo5eoZ3giUtAow7EkC+A3wf7Rgt0SSXYHbA5+e7RuT/GOSnyS5LMml3eWZQiNJXpDkuCRXJTkhySuY5d3iJLdI8q7uvKuSnJPkC0m2v7E/5Mi8mNsleX+SM5NcnuQHSW7bnfP4JL9JckU3B+aFs1zXg5N8L8mFSa5M8n9JXjzDeQ9N8sUkf+mu88Lu+3af4dzDutvcovtZL+jq+26SHef5M+6U5CNJ/tjNz7o8ya+TPH8537ZOkg8mOaur8RdJHjTDdT8qyeFJzu3OOzXJV6fXluROSb6W5Lzud3NMklcnWX0e9X8mSc1yrJJ8prt8f+Ck7tCbR4Yjnzzte56S5Mcjv4tfJHniXHWMfH+SvKT7HV7e/Y3/KMkDpp23bXf7e3e3+eskVwD/PVp7kgd19VwKHDLy/fN6HHV/H4cluWv3d3ER7bE7W/0nA/t3X/5o6vc0cnyTJB9OclracO3Tuq83nnY9U/PHHpzkjUlOpI0IePI8fodP6Gq+sPsd/qn7e1uzO75k3m2Sf0pyTHfd/9YdXyPJa7q/oyu7v6uvJbnjDLe1Z5Jfdrd1Wfe4+1ySxSPn3D7Jl5KckfbcclZ3nz5qjp/jEV2dL5/l+M/SnqcWdV/v2t3nx3c/9yXd/fq4uX5n3ffPOGcvyVZJDk5yUZKLkxyS5NazXMdTknwz7bF6Vdpj9+tJ7jTtvAK2AXYfeSwtmUOYWebsJdktyfe7Wq5Ie+583gzn3eTnNkk3jsM4JU35FPC+JFtW1Rld23OBvwGHzvQNSV4KfBg4DnhL17wX8PUkL6qqT4yc+wrgv4CjgdcBa9NezP1thuu9BfBTYOuurj8CmwMvBX6RZJeqOuUm/Kz7A5cC7wAW0+YxfTfJG4F3Ax/tbvd5wMeTHFNVPx6p74XAx4CfA28HLgMeAnw0ya2r6t9HbmsvYCPgAOB0YEvg+cAPkjygqo6cVts6tPlUP6f9nrYD/gX4RpI7VNW1c/xs9wd2o91nJ3XX9yRg3ySLq+o/ZvieA4BrgXcB6wEvAr6T5BFV9b/dz7w78E3gD8B/ABcCWwAPBnYAju/O2wU4HLiG9rdxFvCY7rrvDDxjjvrn61jglbS/qa/R5qRBu1/pankb8HrgO8AbgeuAxwFfSvKyqvrwPG7nQOBpwJdpb3qs1f0M30/y+Kr65rTz/xF4Oe1v6GPAxSPHdgGeAOzL0gB2gx5Hna2BHwJfAr4CLK8H7BXAI4AX0v7ejx253anH2Q60v/ffAHcFXgI8MMmuVXXJtOt7L7Co+xkuBv60nNsmydtpf8fH0O6rM4Fbd7+HN7HsEMVXABt3130WcFrX/jlaqPw+7fd6S+CfgJ8luV9V/ba7rWfRfq9Hdtd9BbAV8EhgU+CcLsT+sLvejwGnAJvQ7pt7At9azo/zva6uPYEPTvs5bwPcC/hgVV3TNT8O2Ak4uLudjYFnA19N8oyq+vxybmtGSTagPT9s1dV/DLA78CPg5jN8y8uA84BPdLXfmva38JMkd6uqP3fnPYt2/5xLe06bcs5yankM7bF3FvCfwCXAU4FPJtm+ql4/7Vtu6nObpBujqvzww48F+kELBkULXRvThmq+rjt2c9oL+vd2X18KHDbyvRt2bScA64+0rw+cSPvHv0HXtgEtEB0DrD1y7q266yjg/iPtH6C9ULvztHq3ob3A/MwMP8Ne8/h59+7OPQTISPvLu/aLga1G2hfTehi+MNK2edf2+Rmu/wO00LT9SNs6M5y3Ge1F1f9Maz+sq+PV09r/vWt/2Dx+xplub7Xuui8CFs3w+/gFsOYM98uxI23v687ddI7b/wltfuedRtpCe8FbwINmuP1tR9o+0/41zXjdNe2+37Zr23uGc+/WHXvHDMe+3t3X683xszyuu44XTmtfAziKFqYzrZZrgJ1nqb2AB09rn/fjqGs/ubue59+Ax/leTHuMde1v79pfOq39n7r2t85wHX9i5DE8x+3u2n3PD4GbTTuWkd/d/bvzzp/+90V7E6WAL7LsY/bO3d/ZkSNtX+3u1zWWU9Me3fU9eb6/v2nf/57u+283rf2tXfvd5ngsrt39Do+Z1j7TY+F69xstsBfwnGnf//6u/bBp7TPVsDPtuf4j09pPnv79I8cOA04e+Xp1WoC9ENhipH1N2nPAtcBtpn3/TXpu88MPP27ch8M4JQFQVefRem726poeD9yC9o7/TB5Ce6f2g1W1pPeiu/xBWm/Dg7vmh9Je5Hy4qi4fOfd02rv2SyQJrefkCOCMtGFmmyTZhBYYf95d303xwaqqka+nete+WVVTvQlU1Tm0F2a3GTn3ibTenf1Ga+vqO4QWrB48ch2Xjfxs63Y9C9fSAtY9Z6jtOqb1GrC0J+I2zGHa7d2su72NaL0S69N6Gqb7r6pa0sMycr/slGTnrvmi7vMTksw4KiTJpsB9aL/HJUMLu9/1VG/BvIawrQDPoL2I3H+G++mbtB7Me89xHc+kha2vT/v+DWj39bZc/z75VlUdy8yOrq6ndMQNeRxNOZ/lDK2+AR5H67mZ3nP48a59pvvqo6OP4TlM9eK+tqquHD1QnWnnH1BV03v6p2p4++j5VXU07T74h5EhmhfRnmce1T2PzGTq7/gRSdaf588xaqpHds+phu62ngn8oap+M1Lj6GNx7e6xuDbt8bzzjbz9fwTOpvXGj3rXTCdP1ZBm/e7vd+p5babnn/m6O93Ii6r668jtXU0bHbEa158DfpOe2yTdOA7jlDTq08C3kvwDbQjnL6vqmFnO3a77/McZjk21bT/t83EznDv9+hfTehkfyuxDiG7qggV/mfb1Bd3nk2Y49wJaj+KUqfAz/UX7qM2mLnRzad4OPIwWEkZNf7EL8NfpL4xpw7Cg/V6WK21Ri71pw962muGUDWdomymcTN0v23fHP0R78fYR4F1JfkwbHvmFLhTD8v8mjqXdbzd6zuUNtDOt92imv7kpmy3n2NR1rEd7cb286zh+5OvjZztxlmM35HE05cRaMUPetgOOqqplVtqtqr8nOZ7WOzrd8n6+6W5D+xs/ep7nz/b7uY6Z/0b/SAs/29GeK95BG8L8deC8JIcD3wa+WN1w1Ko6PMkBtDe1npHkV7TH8hennuvS5pYuZllXVNVFVfWHJL/pvvd11RZP2Y0W/F89+g3dmx9voz1uNp2h/g1YdpjvfGwP/Gr6/V9VZya5cPrJSe5K63W8P+1NhVEzPd/N1435u71Jz22SbhzDnqRR3wXOoC1n/wDa3J1xm3pH/n+Z5d3qFWC2F8qztWeGy3vS5h/N5C+wJHgdQXuR9X7g97SeouuA1wIPvAE1TK9jNp8HHk3rrTmC9mLqWtq8pVdyIxfmqqrzktwDuB+tN2o32hyffZI8sqp+dmOud6abmqlxtt7E5Uh3XY9g9t/pTC9Up1/HOcDTl3POH6Z9vbxer/n2iM1lRV3POG57avjqyrjuZW+o6s9Jbgc8qPvYnTb/b58ku1XVid15z07yHtrfxv1oc3Zfn+QVVfUh2psk04PQ/iwd9XAA7fH8QNrz1J60v7HPTp3c9fZ9j/aGwQdow34v6s57Du1vaqWOrkqyNe054GJa4PsTbXREdfWPe7XTm/rcJulGMOxJWqKqru3e9X4tbc7cF5Zz+lTv2O2BH0w7drtp50x93mk55045hzYPZP0ZhrxNgqkFDc6dR30Poi1i8tyqWmbYXbd4yArVLd7waODAqnrxtGPThwKO2pnr975Mvw/pehMO6z5IW9Hv18AbgEex9AXy7We4jZ1oL26n96pOd3533RtV1ehWATP1CC4vRPwZeDhw6nKGVc7lz8COwM+r6tK5Tr6RbsjjaGXc9m2TrDHau9cF6x1XwO0eTwtUdwZ+eRNqXI32Nzp91dGp38+SYFZte4D/6T5I8kjaoiuvos1FnDrvD7Sg/p7ucfML4J1JphYVesi02/rryOXP0+bu7ZnkJ7Sh3d+vqtE3f+5E+7nfUlVvHr2iLH9l3Ln8BbhNktVHe/eSbM71Rw48jhbo9qiqH02rYWqO9qj5hvKpOmDmx/rK/ruVdAM4Z0/SdB8D9gFePDqHaAbfp71L/M8Z2eeru/zPtEUnvj9y7hXAP2VkX64kt2Jar0k3LOpzwK6ZZYn8bnhUXw6mvUjaJ8n1Vr9L2zJire7LqRdjmXbOQ7lp82VmM9vtbU5bAXQ2r0y3DH53/tT98qepoNTN9ZnuONr9uhFAN9/qp8Bjktxh5PpCewMB2up9yzM1lG96OP3XGc6dCmAbzXDswO7zOzLDlg9J5hrCCa0HZzXa6qPXM8/rmMsNeRytaF+nDVec/rfxgq59rvtqLlOrTb5j9O9rynLm1Y36evf5taPnd39fewA/nhpGPMvf6NQcuo26czZKssxrn6q6kBYY16YtJHNlVf3vtI9jRs4/hzY89PG0eYnrM7K6ame2x+IduGnzVr9BGzq857T218xw7mw1vICley+OupSZH0sz+Q1wKvCcJEuuK23bialFV74xz+uStBLZsydpGVV1Km3O11znXZjk1bQl43+Rbv8z2lCnHYAXVdVF3bkXpG1r8F7gp13v4drAi2m9J3eddvWvB+4LHJzkYNqiLFfT5s49ktabtNeN/iFvgqo6PclLgE8CxyY5kLYq3WLgjrQ5RLejrWz3Y7plydP2qzoduAttmfPfd+evyNouSfI94Jlpe7z9ivY7exHtxexs82LWAI5M8gXaHLUX01ZjHd1PbN8uBH6P9vPeHHhKd/7oYhH/Qtt64ciRXpJH0+Ysfr6qpvdeTfcF2tyrTyTZidbT93Da8vjTf97zkpwAPDVt37ezgcuq6pCq+lWSvWl/y79L8iVa78zmtMUlHklbOXBWVfXlJJ8GXpbkbrTtLM6lrVZ6b9rf+U2ag3hDHkcrwbtp23J8uPv5fkt7LD6PNuTv3Tflyqvql0neRQsiv0nyRdrfw3a03rBdab34y7uO73fPAU8FNkxyKEu3XriSZf9Gv9fNWzuStm3DBixd0XIq/O9Je3Pja7QVUK+hDfd8GHBwVV0xzx9vf1rY/E/a8MyvTzt+LG2Y8Ku7N7j+ROstfRHtsX/3ed7OdO+mvRGzb5K7d7dxf9rf47nTzv02bWjsgUk+RJt/fF/a3/6JXP814M+B5yV5K0vn2B4yutDMlG4UyMtobwj8KsknaEPUn0LbguIdtXRbB0l9WhlLfPrhhx+rxgcjWy/M49xltl4YaX8crTfnsu7jp8A/znIdL6K96LmK9kLrFbT5KzMtC782bW+039N6jy6hvQDZF7jnDD/DXvP4GfZm2vLmXfu2zL6E/2GMLDk+0n5f2gudv9GC6F9pe139KyPLzNOGc32H9kLrku767scMWwws57ZmrW+GczehBdG/0l4M/57WU7PX9N/zyO/j9rTNv8/qvueXwEOmXe/jaatYnt7df+fQQt0TZqjhzrQXv+d35x5LW7xi9XneH/ekLd9+Je0F7CdoL9yLka0XunN37c6dmot08rTjj6LNRZ2q5TTai+AX34DHybNoAeLirqaTacv8P2W+99FMtd+YxxHLWR5/Odd9vft+5Nhi2qI7p9OCz+m04LnJfK9jHrf/tO4+uqT72Y6jzRlbcz6PYVooeU33d3RVd19+HbjjtPNeQOsFPYv2mDyTNpzzASPn3IUW1E7oarmYNoT5X4G1bsDPtCZtPmwB+85yzja0vRDPoYWuX3b38/X+7mdpm/F3TlsF88td7RfTViW99Ux/G7S5tT/ufvcX0oa03oEZnmtoi8h8pfv9Xjdaz0znd+27d7/zqcfGb4HnzXDebN+/LfN8bvPDDz9u3MfUHjeSJEmSpAFxzp4kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGaI2+C7ipNtlkk9p22237LkOSJEmSevHrX//63KpaPL19lQ972267LUcddVTfZUiSJElSL5KcMlO7wzglSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGaJVfjVOSJEmSVjXXXXcd5557LhdeeCHXXnvtrOetvvrqbLDBBmyyySasttoN66sz7EmSJEnSmJ1++ukkYdttt2XRokUkud45VcU111zD2Wefzemnn87WW299g27DYZySJEmSNGaXXXYZW265JWuuueaMQQ8gCWuuuSZbbrkll1122Q2+DcOeJEmSJPVgvsMyb+jwzSXfd6O+S5IkSZI00Qx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJknpQVSv0vOkMe5IkSZI0ZosWLeKKK66Y17lXXHEFixYtusG3YdiTJEmSpDHbdNNNOeOMM7j88stn7bmrKi6//HLOOOMMNt100xt8G2vc1CIlSZIkSTfM+uuvD8Bf//pXrrnmmlnPW7RoEZttttmS828Iw54kSZIk9WD99de/USFuvhzGKUmSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAFao+8CJEmSJK369t57775LGJQV8fu0Z0+SJEmSBsiePU2MU99yx75LGIyt3/T7FX6d9/3v+67w61zIfvLPP1nh13n4bruv8OtcyHY/4vAVfp0f+tdDVvh1LlQv+8/HrPDrfPszn7jCr3Mhe/1nv7zCr/PYt/9whV/nQrXz6x/YdwkaA3v2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAFaMPvs3f3fD+i7hEH59Xv27LsESZIkScthz54kSZIkDZBhT5IkSZIGaGxhL8laSfZLckqSS5L8LskjRo4/Ocmx3bFjkvzjuGqTJEmSpKEZ55y9NYDTgN2BU4FHAgcnuSNwDfBZ4LHAd7pjX0qybVX9bYw1SpIkSdIgjC3sVdVlwN4jTYcmOQm4O3A6cGFVfbs79q0klwG3Bgx7kiRJknQD9TZnL8lmwI7AH4GjgGOT7JFk9W4I51XA//VVnyRJkiStynrZeiHJIuBzwP5VdVzXdgDweeBmwNXAk7rewJm+/4XACwG23nrrsdQsSZIkSauSsffsJVkNOJAW6F7WtT0YeDdwf2BN2ry+Tya5y0zXUVWfqKpdqmqXxYsXj6NsSZIkSVqljDXsJQmwH7AZ8ISquqY7dBfgiKo6qqquq6pfAb8AHjzO+iRJkiRpKMbds/dRYGfgMVV1xUj7r4D7TfXkJbkrcD+csydJkiRJN8rY5uwl2QZ4EW3hlbNaJx8AL6qqzyXZG/hyt3DLOcA7qup746pPkiRJkoZknFsvnAJkOcc/BHxoXPVIkiRJ0pD1tvWCJEmSJGnlMexJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAhj1JkiRJGiDDniRJkiQNkGFPkiRJkgbIsCdJkiRJA2TYkyRJkqQBMuxJkiRJ0gAZ9iRJkiRpgAx7kiRJkjRAYwt7SdZKsl+SU5JckuR3SR4xcnztJB9Jcm6Si5IcMa7aJEmSJGlo1hjzbZ0G7A6cCjwSODjJHavqZOAT3Tk7A+cDdxljbZIkSZI0KGMLe1V1GbD3SNOhSU4C7p7kZsAewK2q6uLu+K/HVZskSZIkDU1vc/aSbAbsCPwR2BU4BdinG8b5+yRPWM73vjDJUUmOOuecc8ZUsSRJkiStOnoJe0kWAZ8D9q+q44BbAXcALgK2AF4G7J9k55m+v6o+UVW7VNUuixcvHlfZkiRJkrTKGHvYS7IacCBwNS3UAVwBXAO8raqurqrDgR8BDx13fZIkSZI0BONcoIUkAfYDNgMeWVXXdIf+b4bTa2yFSZIkSdLAjLtn76O01TYfU1VXjLQfQVuh87VJ1khyX+ABwHfHXJ8kSZIkDcI499nbBngRbUuFs5Jc2n08o+vheyxtO4aLgH2BPbv5fJIkSZKkG2icWy+cAmQ5x/8I3Htc9UiSJEnSkPW29YIkSZIkaeUx7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDNK+wl+QdSdYe+fqRSW4+8vX6SQ5YGQVKkiRJkm64+fbsvQZYd+Trg4DNR76+OfCMFVWUJEmSJOmmmW/YyxxfS5IkSZImiHP2JEmSJGmADHuSJEmSNEBr3IBzX5zk0pHve16S87qv11uxZUmSJEmSbor5hr1TgeeMfH0W8PQZzpEkSZIkTYB5hb2q2nYl1yFJkiRJWoFWyJy9JOskef6KuC5JkiRJ0k13k8Jeknsn+SRtWOf7V0hFkiRJkqSb7AaHvSQbJ3lVkmOAHwObAs/rPkuSJEmSJsC8w16ShyX5EnA6sAfwPuA64P9V1cFVdflKqlGSJEmSdAPNa4GWJCcDVwIHAv9eVSd37R9daZVJkiRJkm60+fbs3RI4GvgdcNpKq0aSJEmStELMN+xtDRwFvBf4a5IPJLkHUCutMkmSJEnSjTavsFdVf6uq91TVzsATgfWBH9GGgb4oye1XYo2SJEmSpBvoBq/GWVVHVtVzgC2AlwL3Bn6f5NgVXZwkSZIk6ca50fvsVdXFVfWxqtoVuDPwvRVXliRJkiTpppjvapzfXNmFSJIkSZJWnHmFPeDRwCnAYSuvFEmSJEnSijLfsPce4FnAbsCngc9U1ekrrSpJkiRJ0k0y39U4XwNsBbwS2AX4c5JvJ3likkUrs0BJkiRJ0g037wVaquraqvpmVf0jsB1t64W3AWckWXcl1SdJkiRJuhFu7Gqc6wAbAOsCl+Lm6pIkSZI0UeYd9pLcPMmzkxwB/B7YBnh2VW1fVZettAolSZIkSTfYfLde2Bd4MvBnYD9gj6q6cCXWJUmSJEm6Cea7GufzgFOBM4FHAI9Icr2TqmqPFVeaJEmSJOnGmm/YOwDn5UmSJEnSKmNeYa+q9lrJdUiSJEmSVqAbuxqnJEmSJGmCGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGaGxhL8laSfZLckqSS5L8LskjZjjvTUkqyYPHVZskSZIkDc04e/bWAE4DdgduAbwBODjJtlMnJLk18CTgzDHWJUmSJEmDM7awV1WXVdXeVXVyVV1XVYcCJwF3Hzntw8BrgKvHVZckSZIkDVFvc/aSbAbsCPyx+/pJwFVV9T/z+N4XJjkqyVHnnHPOSq5UkiRJklY9vYS9JIuAzwH7V9VxSdYD3gH8y3y+v6o+UVW7VNUuixcvXpmlSpIkSdIqaexhL8lqwIG0oZov65r3Bg6sqpPHXY8kSZIkDdFYw16SAPsBmwFPqKprukMPAl6e5KwkZwFb0RZvec0465MkSZKkoVhjzLf3UWBn4MFVdcVI+4OARSNf/wp4FfDtMdYmSZIkSYMxtrCXZBvgRcBVwFmtkw+AF1XV56adey1wQVVdOq76JEmSJGlIxhb2quoUIHOe2M7dduVWI0mSJEnD1tvWC5IkSZKklcewJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEy7EmSJEnSABn2JEmSJGmADHuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkDZNiTJEmSpAEaW9hLslaS/ZKckuSSJL9L8oju2L2SfD/J+UnOSfKlJJuPqzZJkiRJGppx9uytAZwG7A7cAngDcHCSbYENgU8A2wLbAJcAnx5jbZIkSZI0KGuM64aq6jJg75GmQ5OcBNy9qr4yem6SDwGHj6s2SZIkSRqa3ubsJdkM2BH44wyHd5ulXZIkSZI0D2Pr2RuVZBHwOWD/qjpu2rE7AW8CHruc738h8EKArbfeeiVWKkmSJEmrprH37CVZDTgQuBp42bRjOwDfBv6lqo6c7Tqq6hNVtUtV7bJ48eKVWq8kSZIkrYrG2rOXJMB+wGbAI6vqmpFj2wD/C7y1qg4cZ12SJEmSNDTjHsb5UWBn4MFVdcVUY5ItgR8CH6qqj425JkmSJEkanLGFva7n7kXAVcBZrZMPurYdgO2BvZPsPXWgqtYdV32SJEmSNCTj3HrhFCDLOWWfcdUiSZIkSUPX29YLkiRJkqSVx7AnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAGfYkSZIkaYAMe5IkSZI0QIY9SZIkSRogw54kSZIkDZBhT5IkSZIGyLAnSZIkSQNk2JMkSZKkATLsSZIkSdIAjS3sJVkryX5JTklySZLfJXnEyPEHJTkuyeVJfpRkm3HVJkmSJElDM86evTWA04DdgVsAbwAOTrJtkk2ArwJvBDYCjgK+OMbaJEmSJGlQ1hjXDVXVZcDeI02HJjkJuDuwMfDHqvoSQJK9gXOT7FRVx42rRkmSJEkailRVPzecbAacAtwFeAmwZlW9ZOT4H4A3V9VXZvjeFwIv7L68LfCnlV7w+GwCnNt3EVou76PJ5v0z+byPJpv3z+TzPpp83keTbYj3zzZVtXh649h69kYlWQR8Dti/qo5Lsi5wzrTTLgLWm+n7q+oTwCdWbpX9SHJUVe3Sdx2anffRZPP+mXzeR5PN+2fyeR9NPu+jybaQ7p+xr8aZZDXgQOBq4GVd86XA+tNOXR+4ZIylSZIkSdJgjDXsJQmwH7AZ8ISquqY79EfgziPnrQPcumuXJEmSJN1A4+7Z+yiwM/CYqrpipP1rwB2SPCHJzYA3Af+3QBdnGeTw1IHxPpps3j+Tz/tosnn/TD7vo8nnfTTZFsz9M7YFWrp9804GrgL+PnLoRVX1uSQPBj4EbAP8Atirqk4eS3GSJEmSNDC9rcYpSZIkSVp5xr5AiyRJkiRp5TPsSZIkSdIAGfakOXTbhUjSICVZPcn+SdbquxZpVdQ9hk70MTSZuvvnLQv1/nHOXs+SHAjMdCdcBZwOfL2qjh5vVZqSZHXaPpAbVNVVfdcjrWq6x9APgIf5GJpcSc4Eth7ZEkkTxMfR5EtyPHCPqrqo71p0fUnOBTatquv6rmXc7LHo30XAY4HQwl2APYBradtU/CzJnv2Vt7BV1bXA8cDGfdei5UuyKMn9kjyl+3qdbs9O9ah7DG2H/28m3X8B+yRZ1Hchuj4fR6uE9wMHJ9k9ya2TbD/10XdhAuAA4MV9F9EHe/Z6luR7wD5V9ZORtnsDb6mqhyR5OPD+qtqptyIXuCSvBp4KfIAWyJc8aKrqh33VpaWS3BH4Jq1H/FZVtW6SRwLPrqqn9FudkjwX2A14M9d/DC24d1knUZLTgFvS3mg8h2Xvo637qktL+TiabElmuw+qqlYfazG6niQ/Bu4JnAGcxrKPn936qmscDHs9S3IRsHFV/X2kbRFwblXdIkmAS6pq3d6KXOCSnDTLoaoq37GbAN2T+Mer6sAkF1TVhl2v3vFVtWXf9S10Iy+CRv/hBF8ETYwku892rKoOH2ctmpmPI+nGS/Ls2Y5V1f7jrGXcDHs9S3I48HPgzVV1ZZKbAXsD96mq3bru/8N8Z1WaXZILgI2qqpKcX1Ubde1LLqs/SbaZ7VhVnTLOWqRVlY+jVUOSrYEtgdOr6rS+61GTZPVuOPSC49jv/j0buB9wcZKzgItpwzSm3oHYCHhpT7Wpk2SNJLsleVo3L2yNvmvSMk4G7j7akGRX4IReqtF0G1bVKTN99F2Ymm7O6z5J/pLkyu7zPknW7Ls2NSOPmdOAq4HTfBxNjiSbd2/gnwB8FTgxyRFJtui5NDVnJflIkvv2Xci4GfZ6VlUnV9V9gFvTFmrZoaruU1UndcePqqpDey1ygUuyE3As8Hng5cAXgOOS7NxrYRr1RuBbSfYB1kzyWuBLwBv6LUud7yX5Y5I3uFjBxHo38GDaAgZ37j4/EHhXn0VpqSTrJzkAuJI27+iKbsuMW/RcmpqPAkfT3tzaHNgQ+C3wsV6r0pSH0lZX/0KSk5L8Rzfff/AcxjkhkmwKLDMvr6r+0lM5GpHkh8C3gfdW94BJ8m/Ao6rqAb0WpyWS3BV4AbAN7Z3vfavq1/1WJViybPzDgafRVhv+I+3Nky9W1d/6rE1NktOBO1fVeSNtmwBHO+91MiT5DLAe8FrgFNpz3duBy6tq1vlIGo9uaf/NR7cv6fZ1O6OqNumvMk3XzVF+GvAE4MyqulPPJa1Uhr2edatt7gdsPu2QE64nRJLzgcWjY727YZznVNWG/VUmrXqS3Jw2iuElwL2qakFucjtpkpwB3GmGsPd/VeUwtAnQTfXYvqouH2lbFzixqjbrrzIBJPkz8MTRvZGT3An4alXt0F9lmi7JZrRV1vcEblNV6/dc0krlvKP+fRh4K7B/VV3RdzGa0V+B3YHRbRbu17VrAiR5yyyHrqItUf6dqjp7jCVpBt0CVI8GngLsAhzZb0Ua8SXgkG4o9Km0XqM3AAf3WpVGXQkspvXqTdmE9jyn/r0b+N8k+7G05/U5tGkG6lmSDWg9eU8H7gV8jzZM/Zs9ljUW9uz1rOs12ri8IyZWkj1oQ84OpT2Bbws8EnhmVX2jx9LUSXIQ8Djgl7QhnFsBuwKHALcC7gg8oaq+01uRC1i35+HTaUM4jwEOAg6qqrN6LUxLdAuxvIF2P21BezPrC8DbqsowMQGSvIHWE/E+loaJVwIHVtXb+qxNTZIHMu0xVFU/6LcqASS5HPgp7XntK1V1Yb8VjY9hr2dJ3gMcW1Wf6rsWzS7JjsCTWfoEfnBVHd9vVZqS5GDaP9WvjbQ9Fnh6VT2l21/nlVV1l75qXMiSHEP7B/v5qjqx73qkVVG37+5zuH4g/5RvGEvLl+TpwM+r6i9Jbknr1bsOeO3Q33g07PUsyZG0HohTgGX+2Kpqt16K0nJ1c46u893uyZHkIto+e6PzKlcHLqiq9Ucv91akNMGSPAA4uapOWmgvhKQVIcmrgB9W1e+S3JM2NPpa2puOP+u3OiU5FnhYVZ2a5PNd8xW0NRn26LG0lc6w17Oux2FGVbX/OGvRzJK8l9aT98skjwK+DBTwlKo6pN/qBJDkN7R3tz800vZPwPOr6q7dZOyjq+qWvRW5gE17EXQv2jwwXwRNkIX8QmhVkeRpwO+q6thutMm+tED+kqo6rt/qlOQ04A5VdVGSHwHfAC4BXlhV9+y3OiW5uHvzdw3gbNow6KuBvw59tVTDnjSHJGcCt66qy5P8gjYJ+yLgv6pqQezRMumS3I22ie3qtP2ntqSFicdX1W+S7Abctqr27bHMBcsXQZNvIb8QWlUkORG4T1WdneQQ4E+0fcN2q6oH9ludRh5D69FGay2uqmuTXFhVG/Rc3oLXbS9zd+AOwN5Vdb9urvI5VTXovSpdjbMHSZ5VVQd2l58723nO45sYa3dBb2PastdfAUiyTc91qdMFutsA96ZtY3Im8LOp/Y6q6gjgiB5LXOhu0QW99Wgbdj+4exH0n30XpiUu7nrA7wAcU1WXdi+EFvVcl5Za3AW9mwH/ADwRuAY4t9+y1DktyX2A2wNHdM9x69PeeFT//hv4FbAm8Iqu7b7A4HvFDXv9eBpwYHf5WbOcU4BhbzIcn+QZwA7A92HJ/lNulTFBumBnoJtMvgiafAv2hdAq5JwkO9BWF/5VVV2VZG0gPdel5t9p0zyupi3xD22rmV/2VpGWqKp3JfkacO3IQmFnAM/vsayxcBinNIck9wA+QHsCf15VndiFv4dX1WxhXStZNzRwziewqtp6DOVoOZI8AtiP7kVQVf26WxntWVX1iH6r05RuHtiSF0Ld12tV1e/7rUwASfai/S+6ljZn/Pvd1kCvqqr791mbZpZkESx5M1LqhWGvZ0l+W1V3naH9qKrapY+apFVBkt1HvrwH8Gzggyzdf+plwAFV5VDBHiVZDbg/8JPRFWx9ETTZutU5r6uqw/uuRUt1PXlU1eXd15sCq7liav+S3A44rxtquy6tp+864D1T95fUB8Nez5JcUlXrTWsL7Qljo57K0ohpS5JvDrwTlySfKEn+QFtJ8IyRtlsB36mqO/RXmWDm5zlNliSHA6+rqp8keQ3wKuDvwIer6h39VieAJIuBK7r5lKvTNli/jrap+nX9VqckRwNPrqo/JfkYcFvgSuBcRwGpT4a9niQ5oLv4FOCL0w5vS7tv7jfWojQjlySffEnOB7arqotG2jYATqqqDXsrTAAk+Rbw1qr6ed+1aGZJzgM27eZTngDsQVsx9ScOhZ4M3WrQL66q3yZ5J/AY2gItP6qqV/ZbnZJcVFW36N6wPxu4He21wklVtWm/1Wkhc4GW/pw4y+UCfkLbjFOTYcsu6K0BPIyRJcn7LUsjvgl8M8nbgNOBrYDXdu3q3ynAt5N8A1hmrmVVvam3qjRqNaCS3Jr2ZuMxAEl8s2Ry7Aj8rrv8TOA+tK0X/ggY9vp3Zbfi8O2AU6vq3O51w816rksLnGGvJ1W1D0CSn1fVd/uuR8vlkuST78XA3sDHgC1oWy8cDOzTY01a6ubA17vLt+qxDs3ux8CHaFuXfA2gC34u6z85rgXW7BbOuah7E3I1YN2e61LzeeCHwHq0xxLA3YCTeqtIwmGcEyHJ/Wlj77ekLQN7YFX9qM+atFQ3f+Wf6JYkr6qDunl873RDaElD0O0j+q+0YYHv6d7UehRwm6p6f6/FCYAkBwLrAxsD362qtya5A/Dlqtqp3+oEkOShwDVTr+GS7AKsX1U/7LcyLWSGvZ4leT7wDuCTtKFOWwPPA95YVfv2WZuWcknyyZNkt26zdJI8cLbz/Cc7ObohTpswsi9YVf2lv4qkVUeStWirDl9De1P4792bxbesqoP6rE1LJdmKNv3DOcqaCIa9niU5HnhSVR090nYn4CtVdZv+KtOobpn4ewFbVNUXk6wDUFWX9VvZwpXkD1MrbXZ77v19htOqqrYfb2WarluS/HPAnWnz9dJ9pqpW77E0dbog8SbgacDG3UITDwV2rKoPLf+7NU7d0M3NqurMvmvRUkm2Br4A3IX2v2fdJE+k7ck7+I27NblW67sAsTFwzLS2PwFuuzAhktwROB7Yl7YxNMDuwKd6K0qMBL3VgcXATlW13bQPg95k+AjwI9rz2sXAhsDHab0Umgz/RZuX/AyWLqDzR+AlvVWkZSTZoFsR+krghK5tj25hKvXv48C3aHP2pvYP/T7wkN4qkrBnr3dJvkkbvvmaqrq86zH6D9oy8o/ptzoBJPkx8PGqOjDJBVW1YXc/HV9VW/Zdn5bsb/SIqnKF1AmU5ALasv7XJLmwqjboHkN/qKrt+q5PkORMYIequizJ+VP7vE7dX/1WJ4AkBwEXAG+hLRa2Ybf33k8dCdS/bvuSxVV1nY8hTRJX4+zfi4CDaCs+nkd75/untKE0mgy3Bz7bXZ4aenZZkpv3V5Km+RxwaJIP0LZeGF3a3zl7/buStnrtNcC53XCnC2gjGzQZrmbaa4IuSJzXTzmawYNoUwmuSTL1v+icJO7hNhnOBnagjQQClgxhP7W3iiQMe5PgNcC/0/Zs2wL4a1Wd3m9JmuZk4O7AUVMNSXalG0ajiTA11Gzvae0FOJSzf0cCTwY+A3wZ+DZwFW2Zck2GLwH7J3klQJLNgffT3ozUZLiItsDRkrl63Rsnzt2bDO+lven4H8AaSZ4GvA54Z79laaEz7PUvtP2nLqPt0fK5XqvRTN4IfCvJx2h7HL2Wtq/bC/otS1McCjjZqurJI1++DvgDbV7LAf1UpBm8DngX8HtgbeDPtHnK7lU5OT4JfCXJ64HVktybtpr3x/otSwBV9aluhNaLgNNoW2q9saq+3mthWvCcszcBupW1HkQbuvk44C/A56rqfb0WpiWS3JUW7rahPYnvW1W/7rcqadXiKoKTqVvk6M3A26vqqm745rnlC4SJkiTAy2lhYhva8MCPAx/wvupX9xj6AfCwqrqq73qkUYa9CZNkS+DTwINckrx/3RP48cDtfAKXbpwkGwIfBp5I23B4nSR7ALtW1Rv6rU4ASc6lLaJzXd+16Pq6/0WfAl7o/6LJlOQU2qrQV/RdizTKrRcmQJJ1kjwzybdoweLvuCT5RKiqa4FrgZv1XYu0Cvsobb7RNrSFQAB+Bjylt4o03QG04emaQN3/oocChvHJtQ/w0STbJFk9yWpTH30XpoXNnr2eJfkS8AjgN7TNOL9UVef2W5VGJXkp8Fja3IjpKz3+pa+6pFVFknNYuorg6JLkF1XVLXouTyzZYuaewBm0oeqjz3O79VWXlkryamADYO+qunqO0zVmSaaC+OgL69A2WHeklnpj2OtZ9+R9UFW5NO+EGnkCn84ncGkekpwA3K+qzpwKe90qgt+rqp36rk+QZNbRJFW1/zhr0cySnAbckjba5ByWDeRb91WXmiTbzHasqk4ZZy3SKMOeJGmlSvL/gD2A1wNfo41meAfwjap6f4+lSauMJLvPdqyqDh9nLZJWHYY9SdJK5SqCky/Jc2c5dBVt+PrPXRhEml2SA1l2COeUqcfQ16vq6PFWJRn2pDklOZLlP4F/taoOGW9VkrTiJDkMuDdwNu157VbAZsBRwLbdaY+tqqP6qE+Q5C2zHJr6X/Sdqjp7jCVpRJIPAc8Cvkmb97oV8BjgINpcyz2AF1eV+4tqrNxUXZrbYbTVUfdn6RP4nsDnaZOvP5XkPVX17t4qlCZcktsCdwbWHW2vqk/1U5Gm+SPtjasPTjUkeRmwE/APtCG4/00LhOrHjrS9eH/J0v9FuwKH0ELFR5I8oaq+01+JC9qOwCOr6idTDd3G92+pqockeTjwftrKt9LY2LMnzSHJL4C9qurYkbadgP2r6p5JdgW+UFW37q1IaYIleR3wJuBo4PKRQ1VVD+ynKo1KcgGw8eg+e93ebudW1YZJ1gL+5uqp/UlyMO1/zddG2h4LPL2qntItsvPKqrpLXzUuZEkuoj2G/j7Stoj2GLpFN5z9kqpad9YrkVYCw540h+4JfNPR+SpJbg6cWVUbdF9f6hO4NLMkfwMeXFX/13ctmlmS44DXVNU3Rtr2AN5TVbdNcgvgxKrapLciF7juf9FG3Z57U22rAxdU1fqjl3srcgFLcjjwc+DNVXVlkpsBewP3qardkmwPHObKqRo3N3qU5nYE8OkkOyS5WZIdgH2BHwMkuSNwZp8FShPuCuC4vovQcr0cOCDJT5IclOQnwIHAP3fH70kbxqn+nAi8ZFrbi7t2gE1Ytudc4/Vs4H7AxUnOAi4GduvaATYCXtpTbVrA7NmT5pBkI+AjwONp81yvAb4K/HNVndvNRVrPhQukmSXZE7gv7V3uZRaQGB02qH4l2YS2LcYWtDewvlVV5/VblaYkuRvtf8/qwBnAlrQ99x5fVb9Jshtw26rat8cyF7wkW9E9htxDWZPAsCfNU5LVgMXAOb5AleYvydTjZfQfTmhz9lbvoSTNonuhumVV/bzvWnR93Rywe7E0kP+sqq7ptypNSbIx8Ehg86p6d5ItgNWq6vSeS9MC5mqc0jx0C7I8Cdisql7W9eat5RwkaV6267sALV+SrYEvAHehhfJ1kzwReHhVPb/P2jSzqjoiyTpJ1qyqy/quZ6HrNr3/Cm27kvsC7wZuA/wbbbVUqRfO2ZPmkORJwJG0ITN7ds3rAe/rrShpFVJVp8z20XdtWuLjwLdoz21TPUXfBx7SW0VaRjc//HjanPH9uubdAbcvmQzvB55SVQ8Hplbk/AVtewypNw7jlOaQ5FjgqVV1dJILumXIFwF/rarFfdcnTaIkn6iqF3aXD2TZIZxLVNWeM7VrvJKcByyuquuSnF9VG3XtF06tOqx+Jfkx8PGqOnDkf9E6wPFVtWXf9S10U/dJd/n8qtqom/5xTlVt3HN5WsAcxinNbVNgarhmjXz2nRJpdieNXD6htyo0X2cDO9B6jgBIcjvABSYmx+2Bz3aXC6CqLuu2AlL/jknysKr67kjbg4Hf91WQBIY9aT5+DTwLOGCk7anAL/spR1ol/CLJ1IbpR/ZaiebjvcChSf4DWCPJ04DXAe/styyNOBm4O21OGABJdsU3UybFv9IeQ98Cbp7k47S5eo/ttywtdA7jlObQLc7yPVpPxb2Aw4AdgYdW1Z97LE2aWElOmvssqqq2X+nFaF6SPBZ4EbANrUfv41X19V6L0hJJHk2bq/cxWrB4O22fvRdU1ff6rE1LVuy+JfBM2mPoNOCzrsSpvhn2pOVIEtpKgucCD2fpE/ihVXVpn7VJ0oqQZHXgB8DDquqqvuvR7JLcFXgBS/8X7VtVv+63KnWPoUuBDXwMadIY9qQ5JLmMtmm6e+tJGqQkpwA7VdUVfdei6+vCxPHA7QwTkynJ0cAjquqvfdcijXLOnjS339KGbR7XdyGStJLsA3w0yZuB0xlZgMo3uvpXVdcmuRa4GWDYm0yfo83Z+wDXfwz9sLeqtODZsyfNIcnbaGPwP0MbNjP6BO7+RpJWeUmmAt3oi4LQ5lWu3kNJmibJS2mLfbyD64eJv/RVl5rlzFN2brJ6ZdiT5pDkR7Mcqqp64CzHJGmVkWSb2Y5V1SnjrEUzGwnk0xnIJc3KsCdJkiTdBEm+UVXX22YhyVer6vF91CSBYU+aU5LFwBVVdWk3SX5P4FraksrOZZG0yktyIMsO4ZxyFW3I4Ner6ujxViWtOpJcXFXrz9B+flVt1EdNErhAizQfh9L2Mvotba7Eo4FrgLsCr+yxLklaUS4CngV8kzY3eSvahtAHATsDr0ny4qo6oL8SF7YkR7L8QP7VqjpkvFUpyVu6i2uOXJ6yPeAwaPVqtb4LkFYBOwK/6y4/A3gE8EDgqX0VJEkr2I7AI6vqWVX1uqp6Fu257tZV9VTg8cDreq1QhwHbAocDn+0+bwMcBZwNfCrJq/sqbgHbqvtYbeTyVsCtaG+cPKm/0iSHcUpzSnIusCXtxdBBVXX7JKsBF1XVev1WJ0k3XZKLgI2r6u8jbYuAc6vqFkkCXFJV6/ZW5AKX5BfAXlV17EjbTsD+VXXPJLsCX6iqW/dW5AKW5AVVtW/fdUjT2bMnze3bwMHAR2lDmgBuB5zRW0WStGL9Dnh7kpsBdJ/fCkzN09sOOL+f0tTZCZi+xcIpwG0BquqXwGbjLkpL/CTJZgBJ1k2yT5I3J1m778K0sBn2pLk9H/gWsB/wH13bJsDefRUkSSvYs4H7ARcnOQu4GNitawfYCHhpT7WpOQL4dJIdktwsyQ7AvsCPAZLcETizzwIXuC8AG3SX30t7/NwL+HhfBUngME5p3rqhm5tVlf9MJQ1Skq2ALYAzq+rUvuvRUkk2Aj5Cmz+5OvB34KvAP1fVuUluC6xXVUf1WOaCleSikSHPZ9NGAF0BnFRVm/ZbnRYyw540hyQb0P7BPhG4pqrWSbIHsGtVvaHX4iRpBUqyKbDMvLyqmj50UD3q3nhcDJzj9j+TI8nZwA60kPfhqtolyRrA+TNtySCNi1svSHP7GHABbdWzY7q2nwH/CRj2JK3ykjycNlR982mHitaLpAmQ5Ba0OXrrdl8DUFU/7LEsNZ8HfgisB3yoa7sbcFJvFUnYsyfNKck5wBZVdc3o5qhTQzZ6Lk+SbrIkJwLvoa3seEXf9ej6kuwFfBi4FLh85FBV1fa9FKVlJHkobQTQj7qvdwHWN4yrT4Y9aQ5JTgDuV1VnToW9JFsD36uqnfquT5JuqiTn07Ze8EXBhEpyBvD8qvp237Vodt3rgy2BM5z3qkngapzS3D4JfCXJA4DVktwb2J82vFOShmA/4Dl9F6HlWgP4Xt9FaGZJNk9yOPBn2sI5JyQ5PMkWPZemBc6ePWkO3cpaLwdeRJu3dyptKeUP+C64pCFIciSwK23ftrNGj1XVbr0UpWUkeRVtPthbXZhl8iT5Ou31wWur6rIk6wDvALarqj16LU4LmmFPkqQFLsmzZztWVfuPsxbNLMlpwC2Bq4HzRo9V1da9FKUlkpwLbF5V14y0rUUbzrlJf5VpoXM1TmkekjwEeCqwaVU9xknXkobEQLdKeGbfBWi5LqBtu3D0SNttgQt7qUbqGPakOST5Z+BfaHP3ntg1XwF8ELhPX3VJ0k2R5FlVdWB3+bmznVdVnxpfVZpNVR3edw1arncD/5tkP9pw6G1o82Df2GtVWvAcxinNoVuS/EFVdXKSC6pqwySrA3+rqo37rk+Sbowk/1NVj+wu/2iW06qqHjjGsjQiyeur6u3d5bfMdl5VvWl8VWk2SR4IPB3YAvgr8IWq+kG/VWmhs2dPmtt6wGnd5al3RxbR5k1I0ippKuh1lx/QZy2a1a1GLm/VWxWal25qh9M7NFHs2ZPmkOTLwG+r6u0j++y9GrhLVT297/ok6aZK8tuquusM7UdV1S591CStSpIsAt4APIulPXsHAm+vKt8cVm8Me9IckmwOHAJsQtso9S/AJcCjq+qs5X2vJK0KklxSVetNawtwXlVt1FNZGjH1ZuMM7X+rqk37qElLJfkv2vYl+7B0zt4bgaOq6pV91qaFzbAnLUeS1YD7Az8D7kh78j4N+KX7HEla1SU5oLv4FOCL0w5vS3udcL+xFqUZzRLIFwFnOX+8f0lOB+5cVeeNtG0CHF1VW/ZXmRY65+xJy1FV1yX5RvcP9pfdhyQNxYmzXC7gJ8CXxluOpus2vC/gZkmOmHb4VsBPx1+VZpAb2C6NhWFPmtsRSe5VVT/vuxBJWpGqah+AJD+vqu/2XY9m9ElaYLgHsN9IewFn44Igk+JLwCFJ9gFOpY0EegNwcK9VacFzGKc0hyQfAZ4GfIM2hHPJg8blriUNQZIHACdX1UlJbgm8C7gOeK1zkydDkp2q6ri+69DMkqxJC3fLbL0AvK2qruqzNi1shj1pDkk+PduxqnrOOGuRpJUhybHAw6rq1CSf75qvABZX1R49lqZOkqcBv6uqY5PcFvgELZC/xBAoaTaGPUmSFrgkF1fV+knWoA0N3Ia2l+hfq2qTfqsTQJITgftU1dlJDgH+BFwK7ObG95Oh21T9aSzt2TvITdXVt9X6LkCadEnOn6X9b+OuRZJWkouTbAbsDhxTVZd27Yt6rEnLWtwFvZsB/wC8HngLcJdeqxIASf4VOAg4H/gWcB7w+a5d6o0LtEhzu96LnW6569V7qEWSVob/Bn4FrAm8omu7L+DwwMlxTpIdaNsA/aqqrkqyNq72OCleBTywqv4w1ZDkQOD7wH/2VpUWPMOeNAuXu5a0UFTVu5J8Dbi2qqa2YDgDeH6PZWlZbwV+DVxL2xcR4MHA0b1VpOlOmPb1XxhZ1E3qg3P2pFkkeTbtHdOPAi8eObRkueuquqaP2iRpRevm690H2JIW9H5aVX/vtyqN6nryqKrLu683BVZzxdR+JBmdDvU84P7A3sDpwFbAG4HDq+qTYy9O6hj2pDm43LWkoUuyE3AIcHPaFjNbAVcCj6mqY/usTUsl2RB4DEsD+aFVNeO8cq18Sa5jac/d6HDa0baqKqd9qDeGPWkeuoULdgU2YeQJvao+1VtRkrSCJPkh8G3gvdW9MEjyb8CjquoBvRYnAJLcm7bwx3HAKcDWwM60++hnfda2UCXZZj7nVdUpK7sWaTaGPWkOSf4R+CzwZ+D2wB+BOwA/9kWQpCHoVh1eXFXXjrStAZxTVRv2V5mmJPkF8F9VddBI21OAf6uqe/RXmaC9OVJV752h/VVV9b4+apLArRek+Xgb8JyquitwWff5hbSJ8pI0BH+lbbsw6n5duybDjsDB09q+DOzQQy26vjfN0v6GsVYhTeNqnNLctq6qL01r2x84C/i3HuqRpBXtdcA3kxxKGyK4DfAo4Jm9VqVRfwaeCnx+pO1JwIkzn65x6DZSB1g9yQNYdu7e9sAl469KWsphnNIckpwA3LfbzPa3wEuBc4GfV9XG/VYnSStGkh2BJwNb0Hr0Dq6q4/utSlOS3Ac4FDieFsi3BW4DPLqq3AqoJ0lO6i5uDZw6cqhobwq/s6q+OfbCpI5hT5pDktcAJ1TVV5LsCXwCuA74z6p6Y7/VSdKK0y0lvxlwdlVd13c9Wla3GuejWBrI/8fVOCdDkgOqas++65CmM+xJc0iy2uiLniRbA+u4HLmkoUiyPvAh2mbdawB/Bw4CXl5VF/VZm5bV/Q/aEjijqk6d63xJC5sLtEjLkWR14LIka021VdWpBj1JA/NBYB3gjsDaI58/2GdRWirJ5kkOp83d+ypwQpIjkmzRc2mivWGS5H1Jfp3klCSnTn30XZsWNsOetBzdMuTHA87NkzRkDweeVVXHV9VV3Vy953TtmgwfBY4GNqqqzYENgd8CH+u1Kk35CHA34C3ARsA/0+bw/VefRUkO45TmkOTVtBXQPgCcTpt0DUBV/bCvuiRpRUlyMrD76ObPSbYFjqiqrfuqS0slORfYvKquGWlbizacc5P+KhNAkr8BO1fVeUkurKoNkmwJHFJVd+u7Pi1cbr0gze0l3ee9p7UXbVllSVrVfRL4fpL3sXTrhVfSFqTSZLgAuB2td2/KbYELe6lG060GTM1vvTTJLYAzcR9E9cywJ82hqrbruwZJWsneTlvd8eksXenx3cCn+ixKy3g38L9J9mNpIH8O4KrQk+FoYHfgB8CRtGGdl9Kmgki9cRinNIck36iqx87Q/tWqenwfNUmSFp5uA+/RQP6FqvpBv1UJIMn2AFX1lySbAu8A1gX2cVE39cmwJ80hycVVtf4M7edX1UZ91CRJK1qS5wJPY2mQOAj4VPlCQZpTkg8CB41ucJ/kPsCTq+oVvRWmBc+wJ80iyVu6i6+mDZ8ZtT1w+6q663irkqQVL8m7gccC72fpEMGX0xaXeHWPpamTZE3gDVw/kL+9qq7sszZBknOALavq6pG2tYDTqmrT/irTQuecPWl2W3WfVxu5DG1hltO4/oItkrSq2gu4W1WdPtWQ5FDgN7Q3vNS/j9IWZHk5SwP562gbrD+3x7rUFNff0mz1GdqksbJnT5pDkhdU1b591yFJK0uSE2lh76KRtg2AX1fVrXsrTEskOQ+4dVVdONK2EXCCUwr6l+QrwEnAq6vquiSrAe8EblNVj+u3Oi1k9uxJc7tiekOSAP+vqv6jh3ok6SabWlCi837gq0neSdtPdCvg33FD6ElyFrA2y261cHPa8v7q378AhwJnJjkF2Jp23zym16q04NmzJ80hyZ9pQ5leXFUXdC+QDgSuq6r79VudJN04Sa6jDT3Lck6rqlp9TCVpmm71zSm70lbi/G+WBvJ/Aj5fVe/qoTxN0/Xm7Uq7b04DfllV1/VblRY6w540hyTr0N71fjjwGeClwHuBd/kkLklaWZKcNI/Tqqq2n/s0SQuRYU+ahySLaRul3gHYH3iuy5FLGookH6yql8/Q/n6XjZekVZcrBElzSPIo4GjgR8CdaKuhHZlku14Lk6QVZ69Z2p81ziI0uyTfmKX9q+OuRdKqwwVapLl9DNizqv4XIMk/AK8HjgI27rMwSbopuo3UAdYYuTxle+DcMZek2T1glvb7j7MISasWw540tzsBuyTZD9i0qh6T5NvAVT3XJUk31VTP3Zos24tXwNnAs8dekZaR5C3dxTVHLk/ZnrbnniTNyLAnze0ZwCuATwJP7NquAP4ReHc/JUnSTVdVDwBI8raqekPf9WhGW3WfVxu5DC2QnwbsPe6CJK06XKBFmkO32fCDqurkJBdU1YZJVgf+VlUO45Q0GEk2BdYdbauqv/RUjkYkeUFV7dt3HZJWLfbsSXNbj/buKbR3UgEWAVf3U44krVhJHgZ8Cth82qEC3GdvAlTVvkluQVskbHog/2E/VUmadIY9aW5HAP8PePtI28tpq3NK0hB8BHgrsH9VXdF3Mbq+JHsBHwYuBS4fOVS0uXuSdD0O45TmkGRz4BBgE2BL4C/AJcCjq+qsPmuTpBUhyfnAxu4fOrmSnAE8v6q+3XctklYdhj1pHpIEuAewDW1I5y+r6rp+q5KkFSPJe4Bjq+pTfdeimSU5G9iiqq7tuxZJqw7DniRJC1ySI4Fdacv4LzNioap266UoLSPJq2hzyN/qm42S5suwJ0nSApdk1v30qmr/cdaimSU5DbglbXGw80aPVdXWvRQlaeIZ9iRJkiZckt1nO1ZVh4+zFkmrDsOeJEkLXDcv+fnA04BNqupOSXYDbllVB/dbnSTpxlqt7wIkSVLv3gI8D/gEMDUk8HTgNb1VpGUkWSvJ25P8JclFXdtDk7ys79okTS579iRJWuC6+WB3rapzk1xQVRt2vX3nV9WGfdcnSPIR2vY/7wS+XVUbJNkS+F5V3b7f6iRNKjdVlyRJq9M264a2STfAuiNt6t/jgB2q6rIk1wFU1Rld4JOkGTmMU5Ik/Q/wviRrwZI5fG8FDum1Ko26mmlv0idZzLSVOSVplGFPkiS9CtgcuAi4Ba1HbxucszdJvgTsn2Q7gCSbAx8CDuq1KkkTzTl7kiQJgCSb0RZoOa2qzprrfI1PkjWBdwEvANYGLgf2BV5TVVf3WZukyWXYkyRpAUqS6l4EJJl1pE9VXTe+qjQf3fDNc8sXcZLmYNiTJGkBSnJxVa3fXb6OpQuzLDkFqKpafezFCYAk21bVyd3l7Wc7r6r+MraiJK1SXI1TkqSFaXS5/u16q0LL83tgve7yCbRAnmnnFG01VUm6Hnv2JEmSJGmA7NmTJGkBSnIg1x+6eT1VtecYypEkrQSGPUmSFqYTRi5vAjybtq/eKbQVOR8D7N9DXeokOZL5BfLdxlCOpFWQYU+SpAWoqvaZupzku8CjqurIkbZ/AN7YR21a4pMjl28NPJcWwKcC+bOBT/VQl6RVhHP2JEla4JJcBGxSVdeMtC0CzptasVP9SvJz4HlV9ceRttsBn6qqe/VXmaRJNuu+OpIkacH4LfCOJDcH6D6/Hfhdn0VpGTsDJ05rOwnYqYdaJK0iDHuSJGkv4L7ARUnOBi4C/gFwcZbJcTjwmSS3SXLzJDsC+wFHzvF9khYwh3FKkiQAkmwNbA6cWVWn9l2PlkqyEfAR4PG0ffX+DnwV+OeqOrfP2iRNLsOeJElaIkkY2bi7qq7rsRxNk2Q1YDFwjveNpLk4jFOSpAUuyRZJvpbkPFqP0TUjH5os6wBrA9sm2T7J9n0XJGlyGfYkSdLHgauBBwGXAncDvgm8uM+itFSS2yX5LW0+5Qndx5+7D0makcM4JUla4Loeva2r6rIkF1bVBt0csZ9Wlas9ToAkhwG/Ad5CW4VzW+A/aPfRZ/urTNIkM+xJkrTAJfkbsFVVXZXkZOAewMXAuVW1Xq/FCYAkFwCbVtU1I4F8HeAPVbVd3/VJmkwO45QkSb8AHtld/i7wRdpKj0f1VpGmuxJY1F0+t1s5dTVg4/5KkjTpDHuSJOlZtH3cAF4B/BD4A/D0vgrS9RwJPLm7/GXg27T77Ie9VSRp4jmMU5KkBSzJ6sCngBdW1VV916O5ddsvPB1YDzigqi7ruSRJE8qwJ0nSApfkTNoCLW61MIG6QP4D4GEGckk3hMM4JUnSfwH7JFk055kau6q6FtgOX7dJuoHs2ZMkaYFLchpwS+Ba4ByggABVVVv3WZuaJM8FdgPeDJxOu48AqKrr+qpL0mQz7EmStMAl2X22Y1V1+GzHND5JpgLd6Au3qUC+eg8lSVoFrNF3AZIkqXcPmqX9qiTbAt+pqrPHWI+uz730JN1g9uxJkrTAJTkIeBzwS+A0YCtgV+AQ4FbAHYEnVNV3eitSknSD2bMnSZJWA55aVV+bakjyWODpVXWvJM8G3gkY9nqS5ECWHcI55SraHL6vV9XR461K0qRzVSdJkvQw4JvT2g4FHtFd/iyw/Vgr0nQXAY+lzdM7vfu8B21RnZ2BnyXZs7/yJE0ie/YkSdKJwEuAD420vbhrB9gEuHzcRWkZOwKPrKqfTDUkuTfwlqp6SJKHA+8HDuipPkkTyDl7kiQtcEnuBnwVWB04A9iS1mP0+Kr6TZLdgNtW1b49lrmgJbkI2Liq/j7Stgg4t6pukSTAJVW1bm9FSpo4hj1JkjQVHO4FbAGcCfysqq7ptypNSXI48HPgzVV1ZZKbAXsD96mq3ZJsDxzmvoiSRhn2JEmSJlyS7YDPAbsA5wMbAUcBz6yqvyTZBbhlVR3aY5mSJoxhT5IkaRWRZCu63teqOrXveiRNNsOeJEnShEvy26q66wztR1XVLn3UJGnyufWCJEnS5NthekO3KItbYkialVsvSJIkTagkU1sprDlyecq2wB/HW5GkVYlhT5IkaXKdOMvlAn4CfGm85UhalThnT5IkacIleVhVfbfvOiStWpyzJ0mSNPmu7rZfIMktk+yf5NNJbtl3YZIml2FPkiRp8n0EuLa7/D5gEXAd8IneKpI08RzGKUmSNOGSXFxV6ydZAzgb2Aa4GvhrVW3Sb3WSJpULtEiSJE2+i5NsBtwBOKaqLk2yJq2HT5JmZNiTJEmafP8N/ApYE3hF13Zf4Li+CpI0+RzGKUmStApIsiNwbVWdOPL1WlX1+34rkzSpDHuSJEmSNEAO45QkSZpASY6tqp27y6fRNlK/nqraeqyFSVplGPYkSZIm0wtGLj+ztyokrbIcxilJkjThupU39wLuAqw7eqyq9uyhJEmrAHv2JEmSJt/+wJ2BQ2j77EnSnOzZkyRJmnBJLgC2q6oL+65F0qpjtb4LkCRJ0pxOBdbquwhJqxZ79iRJkiZQkgeOfHlX4EnAB5g2jLOqfjjOuiStOgx7kiRJEyjJSfM4rapq+5VejKRVkmFPkiRJkgbIOXuSJEmSNECGPUmSJEkaIMOeJEmSJA2QYU+SJEmSBsiwJ0mSJEkD9P8BfSjxct4j9K8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1080x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "graph_cv_model_performance(meta_results_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "strong-neutral",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "I guess with the reduced data set, a plain `Ridge` model is more accurate than the variety of ensembles that I tested. I was curious if it maybe just had one or two _really_ good years in the CV range that increased its mean accuracy, while ensembles were a bit more consistent, but it seems that all models were bad in 2017 and 2019 and better in the other years, so `Ridge` is just more accurate.\n",
+    "\n",
+    "It's possible that with param tuning, some of the gradient-boosted tree models would surpass `Ridge`, as there are more dials to turn, but I doubt the difference would be significant enough to make it worth the trouble."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hollywood-dutch",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "augury",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/save_default_models.py
+++ b/scripts/save_default_models.py
@@ -12,10 +12,7 @@ import pandas as pd
 from kedro.extras.datasets.pickle import PickleDataSet
 
 from tests.fixtures.fake_estimator import pickle_fake_estimator
-from augury.ml_estimators import (
-    StackingEstimator,
-    ConfidenceEstimator,
-)
+from augury.ml_estimators import StackingEstimator, BasicEstimator, ConfidenceEstimator
 from augury.ml_data import MLData
 from augury.ml_estimators import estimator_params
 from augury.settings import SEED, PREDICTION_DATA_START_DATE
@@ -69,7 +66,7 @@ def main():
             {**data_kwargs, "data_set": "legacy_data"},
         ),
         (
-            StackingEstimator(name="tipresias_2021"),
+            BasicEstimator(name="tipresias_2021"),
             {**data_kwargs, "data_set": "full_data"},
         ),
     ]

--- a/src/augury/ml_estimators/__init__.py
+++ b/src/augury/ml_estimators/__init__.py
@@ -2,3 +2,4 @@
 
 from .stacking_estimator import StackingEstimator
 from .confidence_estimator import ConfidenceEstimator
+from .basic_estimator import BasicEstimator

--- a/src/augury/ml_estimators/basic_estimator.py
+++ b/src/augury/ml_estimators/basic_estimator.py
@@ -1,0 +1,38 @@
+"""Estimator class for non-ensemble model pipelines."""
+
+from typing import Union
+
+from sklearn.base import BaseEstimator
+from sklearn.pipeline import Pipeline, make_pipeline
+from sklearn.linear_model import Ridge
+
+from .base_ml_estimator import BaseMLEstimator, BASE_ML_PIPELINE
+
+
+BEST_PARAMS = {"min_year": 1965}
+
+PIPELINE = make_pipeline(BASE_ML_PIPELINE, Ridge())
+
+
+class BasicEstimator(BaseMLEstimator):
+    """Estimator class for non-ensemble model pipelines."""
+
+    def __init__(
+        self,
+        pipeline: Union[Pipeline, BaseEstimator] = None,
+        name: str = "basic_estimator",
+        min_year: int = BEST_PARAMS["min_year"],
+    ) -> None:
+        """Instantiate a StackingEstimator object.
+
+        Params
+        ------
+        pipeline: Pipeline of Scikit-learn estimators ending in a regressor
+            or classifier.
+        name: Name of the estimator for reference by Kedro data sets and filenames.
+        min_year: Minimum year for data used in training (inclusive).
+        """
+        pipeline = PIPELINE if pipeline is None else pipeline
+        super().__init__(pipeline, name=name)
+
+        self.min_year = min_year

--- a/src/augury/ml_estimators/stacking_estimator.py
+++ b/src/augury/ml_estimators/stacking_estimator.py
@@ -1,6 +1,7 @@
 """Class for model trained on all AFL data and its associated data class."""
 
 from typing import Optional, Union, Type
+import re
 
 import numpy as np
 import pandas as pd
@@ -20,6 +21,8 @@ from augury.types import R
 from .base_ml_estimator import BaseMLEstimator, BASE_ML_PIPELINE
 
 np.random.seed(SEED)
+
+LABEL_PARAM_REGEX = re.compile("correlationselector__labels$")
 
 
 BEST_PARAMS = {
@@ -70,7 +73,7 @@ class StackingEstimator(BaseMLEstimator):
 
     def __init__(
         self,
-        pipeline: Union[Pipeline, BaseEstimator] = PIPELINE,
+        pipeline: Union[Pipeline, BaseEstimator] = None,
         name: Optional[str] = "stacking_estimator",
         min_year=BEST_PARAMS["min_year"],
     ) -> None:
@@ -83,6 +86,7 @@ class StackingEstimator(BaseMLEstimator):
         name: Name of the estimator for reference by Kedro data sets and filenames.
         min_year: Minimum year for data used in training (inclusive).
         """
+        pipeline = PIPELINE if pipeline is None else pipeline
         super().__init__(pipeline, name=name)
 
         self.min_year = min_year
@@ -108,9 +112,14 @@ class StackingEstimator(BaseMLEstimator):
                     }
                 )
 
-        self.pipeline.set_params(
-            **{"pipeline-1__pipeline__correlationselector__labels": y_filtered}
-        )
+        label_param = None
+        for param_key in self.pipeline.get_params().keys():
+            if re.match(LABEL_PARAM_REGEX, param_key):
+                label_param = param_key
+                break
+
+        if label_param is not None:
+            self.pipeline.set_params(**{label_param: y_filtered})
 
         return super().fit(X_filtered, y_filtered)
 

--- a/src/augury/model_tracking.py
+++ b/src/augury/model_tracking.py
@@ -12,6 +12,7 @@ import mlflow
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+import seaborn as sns
 
 from augury.ml_data import MLData
 from augury.sklearn.model_selection import year_cv_split
@@ -270,3 +271,53 @@ def graph_tf_model_history(history, metrics: List[str] = []) -> None:
         plt.legend()
 
     plt.show()
+
+
+def _graph_accuracy_scores(performance_data_frame, sort):
+    data = (
+        performance_data_frame.sort_values("match_accuracy", ascending=False)
+        if sort
+        else performance_data_frame
+    )
+
+    plt.figure(figsize=(15, 7))
+    sns.barplot(
+        x="model",
+        y="match_accuracy",
+        data=data,
+    )
+    plt.ylim(bottom=0.55)
+    plt.title("Model accuracy for cross-validation\n", fontsize=18)
+    plt.ylabel("Accuracy", fontsize=14)
+    plt.xlabel("", fontsize=14)
+    plt.yticks(fontsize=12)
+    plt.xticks(fontsize=12, rotation=90)
+    plt.legend(fontsize=14)
+
+    plt.show()
+
+
+def _graph_mae_scores(performance_data_frame, sort):
+    data = (
+        performance_data_frame.sort_values("mae", ascending=True)
+        if sort
+        else performance_data_frame
+    )
+
+    plt.figure(figsize=(15, 7))
+    sns.barplot(x="model", y="mae", data=data)
+    plt.ylim(bottom=20)
+    plt.title("Model mean absolute error for cross-validation\n", fontsize=18)
+    plt.ylabel("MAE", fontsize=14)
+    plt.xlabel("", fontsize=14)
+    plt.yticks(fontsize=12)
+    plt.xticks(fontsize=12, rotation=90)
+    plt.legend(fontsize=14)
+
+    plt.show()
+
+
+def graph_cv_model_performance(performance_data_frame, sort=True):
+    """Display accuracy and MAE scores for the given of models."""
+    _graph_accuracy_scores(performance_data_frame, sort=sort)
+    _graph_mae_scores(performance_data_frame, sort=sort)


### PR DESCRIPTION
I set out to expand the ensemble that I was using for `tipresias_2021`, but ended up finding that `Ridge` performed better than all the ensemble combinations that I tested. So, that's the new default model.