### PR TITLE
Change cache key from branch name to commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.ref }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Build Docker image


### PR DESCRIPTION
The tutorial that I followed used the SHA, but I figured tying
the cache to the branch made more sense to avoid unnecessary
rebuilds. Now the post-docker/caching actions are hanging, and
an issue suggested that it has something to do with re-using
cache keys, doing stuff in parallel, etc. So, I'm changing the
key back to the original tutorial hoping that fixes it.