### PR TITLE
Change cache key used for Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile*') }}-${{ secrets.CACHE_VERSION }}
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Build Docker image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile*') }}-${{ secrets.CACHE_VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile*') }}-${{ secrets.CACHE_VERSION }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
       - name: Build Docker image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Hashing files makes for a better hash key than the commit SHA,
because if the dependencies don't change, we don't need to change
much from the stored image. Also, following a workaround from
a forum post, I'm adding a secret variable to reset the cache
manually when it gets stuck in a bad state like this.