### PR TITLE
Set local timezones the "correct" way to avoid LMT

### DIFF
--- a/src/augury/pipelines/nodes/base.py
+++ b/src/augury/pipelines/nodes/base.py
@@ -55,7 +55,7 @@ def _localize_dates(row: pd.Series) -> datetime:
         else match_date
     )
 
-    return match_datetime.replace(tzinfo=pytz.timezone(venue_timezone_label))
+    return pytz.timezone(venue_timezone_label).localize(match_datetime)
 
 
 def _format_time(unformatted_time: str):


### PR DESCRIPTION
Apparently, pytz's timezones are buggy if you use them in
datetime's replace, but generally work well when using the
localize method instead. A quick spot check showed the correct
times for upcoming matches.