### PR TITLE
Ignore subdependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     interval: weekly
     time: "19:00"
   open-pull-requests-limit: 10
+  ignored_updates:
+    - match:
+        dependency_name: MarkupSafe
+    - match:
+        dependency_name: Jinja2

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,8 +5,6 @@
 
 responses>=0.10.6,<0.14
 memory_profiler
-MarkupSafe<2.0.0 # Required version for 'cookiecutter' (a 'kedro' dependency)
-Jinja2<3.0.0 # Required version for 'cookiecutter' (a 'kedro' dependency)
 
 # Data packages
 dask[complete]>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ six~=1.15.0 # Required version for TF 2.4.1
 kedro==0.17.0
 gcsfs<0.7 # Needed to access Google Cloud Storage files
 fsspec<0.7 # Needed for DataSet functionality
+MarkupSafe<2.0.0 # Required version for 'cookiecutter' (a 'kedro' dependency)
+Jinja2<3.0.0 # Required version for 'cookiecutter' (a 'kedro' dependency)
 
 # Testing/Linting
 mypy>=0.70 # Need mypy due to references to mypy_extensions in production code


### PR DESCRIPTION
These version numbers are based on the parent version number,
so we don't want to be updating them independently of the parent
package.