### PR TITLE
Fix cleaning fixtures when future matches are unknown

### DIFF
--- a/src/augury/pipelines/match/nodes.py
+++ b/src/augury/pipelines/match/nodes.py
@@ -219,6 +219,7 @@ def clean_fixture_data(fixture_data: pd.DataFrame) -> pd.DataFrame:
     fixture_data_frame = (
         fixture_data.rename(columns={"round": "round_number", "season": "year"})
         .loc[:, SHARED_MATCH_FIXTURE_COLS]
+        .dropna(subset=["home_team", "away_team"])
         .assign(
             venue=lambda df: df["venue"].map(_map_footywire_venues),
             round_type=_round_type_column,

--- a/src/augury/pipelines/match/nodes.py
+++ b/src/augury/pipelines/match/nodes.py
@@ -259,6 +259,7 @@ def clean_match_results_data(data_frame: pd.DataFrame):
                 "round": "round_number",
             }
         )
+        .dropna(subset=["home_team", "away_team"])
         .assign(
             date=_parse_dates,
             home_team=_translate_team_column("home_team"),

--- a/src/tests/unit/nodes/test_match.py
+++ b/src/tests/unit/nodes/test_match.py
@@ -79,6 +79,15 @@ class TestMatch(TestCase, ColumnAssertionMixin):
         self.assertEqual(clean_data["date"].dt.tz, pytz.UTC)
         self.assertFalse((clean_data["date"].dt.time == time()).any())
 
+        with self.subTest("when some teams are blank"):
+            row_count = len(fixture_data)
+            fixture_data.iloc[int(row_count / 2) :, :]["home_team"] = np.nan
+            fixture_data.iloc[int(row_count / 2) :, :]["away_team"] = np.nan
+            clean_data = match.clean_fixture_data(fixture_data)
+
+            self.assertFalse((clean_data["home_team"] == 0).any())
+            self.assertFalse((clean_data["away_team"] == 0).any())
+
     def test_clean_match_results_data(self):
         full_match_results = CandyStore(seasons=1).match_results()
         round_number = FAKE.pyint(1, full_match_results["round_number"].max())

--- a/src/tests/unit/nodes/test_match.py
+++ b/src/tests/unit/nodes/test_match.py
@@ -119,6 +119,15 @@ class TestMatch(TestCase, ColumnAssertionMixin):
         # Dates have real times
         self.assertFalse((clean_data["date"].dt.time == time()).any())
 
+        with self.subTest("when some teams are blank"):
+            row_count = len(fake_match_results)
+            fake_match_results.iloc[int(row_count / 2) :, :]["hteam"] = np.nan
+            fake_match_results.iloc[int(row_count / 2) :, :]["ateam"] = np.nan
+            clean_data = match.clean_match_results_data(fake_match_results)
+
+            self.assertFalse((clean_data["home_team"] == 0).any())
+            self.assertFalse((clean_data["away_team"] == 0).any())
+
     def test_add_elo_rating(self):
         valid_data_frame = self.data_frame.rename(
             columns={


### PR DESCRIPTION
With the uncertainty of finals, some matches appear in the
fixture without teams listed yet. We want to drop those from
our data.