### PR TITLE
Bump stats models to 0.12.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pandas==1.3.2
 scikit-learn==0.24.1
 xgboost==1.4.2
 mlxtend==0.19.0
-statsmodels==0.11.1
+statsmodels==0.12.2
 scipy==1.7.1
 tensorflow==2.6.0
 six~=1.15.0 # Required version for TF 2.4.1


### PR DESCRIPTION
This will hopefully address the deprecation warnings from the
newer version of numpy.