### PR TITLE
Update data scripts to have date params

### DIFF
--- a/scripts/generate_data_sets.sh
+++ b/scripts/generate_data_sets.sh
@@ -4,8 +4,7 @@ DATA_DIR="${PWD}/data"
 mkdir -p "${DATA_DIR}/01_raw" "${DATA_DIR}/02_intermediate" "${DATA_DIR}/05_model_input"
 
 DATA_IMPORT_DIR="${PWD}/src/augury/data_import"
-python3 "${DATA_IMPORT_DIR}/betting_data.py"
 python3 "${DATA_IMPORT_DIR}/match_data.py"
 python3 "${DATA_IMPORT_DIR}/player_data.py"
 
-kedro run --pipeline full
+kedro run --pipeline full $*

--- a/src/augury/data_import/match_data.py
+++ b/src/augury/data_import/match_data.py
@@ -1,5 +1,6 @@
 """Module for fetching match data from afl_data service."""
 
+import sys
 from typing import List, Dict, Any
 from datetime import date
 import os
@@ -134,9 +135,22 @@ def fetch_match_results_data(
 
 
 if __name__ == "__main__":
-    last_year = date.today().year - 1
-    end_of_last_year = f"{last_year}-12-31"
+    script_args = sys.argv[1:]
+
+    if "--start_date" in script_args:
+        start_date_arg_index = script_args.index("--start_date") + 1
+        start_date_arg = script_args[start_date_arg_index]
+    else:
+        start_date_arg = f"{FIRST_YEAR_OF_MATCH_DATA}-01-01"
+
+    if "--end_date" in script_args:
+        end_date_arg_index = script_args.index("--end_date") + 1
+        end_date_arg = script_args[end_date_arg_index]
+    else:
+        last_year = date.today().year - 1
+        end_of_last_year = f"{last_year}-12-31"
+        end_date_arg = end_of_last_year
 
     # A bit arbitrary, but in general I prefer to keep the static, raw data up to the
     # end of last season, fetching more recent data as necessary
-    save_match_data(end_date=end_of_last_year)
+    save_match_data(start_date=start_date_arg, end_date=end_date_arg)

--- a/src/augury/data_import/player_data.py
+++ b/src/augury/data_import/player_data.py
@@ -7,6 +7,7 @@ import math
 from functools import partial
 import os
 import json
+import sys
 
 from augury.data_import.base_data import fetch_afl_data
 from augury.settings import RAW_DATA_DIR, PREDICTION_DATA_START_DATE
@@ -173,9 +174,22 @@ def fetch_roster_data(
 
 
 if __name__ == "__main__":
-    last_year = date.today().year - 1
-    end_of_last_year = f"{last_year}-12-31"
+    script_args = sys.argv[1:]
+
+    if "--start_date" in script_args:
+        start_date_arg_index = script_args.index("--start_date") + 1
+        start_date_arg = script_args[start_date_arg_index]
+    else:
+        start_date_arg = f"{EARLIEST_SEASON_WITH_EXTENSIVE_PLAYER_STATS}-01-01"
+
+    if "--end_date" in script_args:
+        end_date_arg_index = script_args.index("--end_date") + 1
+        end_date_arg = script_args[end_date_arg_index]
+    else:
+        last_year = date.today().year - 1
+        end_of_last_year = f"{last_year}-12-31"
+        end_date_arg = end_of_last_year
 
     # A bit arbitrary, but in general I prefer to keep the static, raw data up to the
     # end of last season, fetching more recent data as necessary
-    save_player_data(end_date=end_of_last_year)
+    save_player_data(start_date=start_date_arg, end_date=end_date_arg)


### PR DESCRIPTION
We use smaller data sets in production, so it's more convenient
to be able to limit date ranges via the script rather than
manually filtering afterwards.