### PR TITLE
Fix dependency conflicts

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -13,6 +13,7 @@ category_encoders
 
 # Kedro packages
 ipython==8.1.1
+setuptools>=60 # Version requirement of ipykernel
 isort>=4.3.21, <6.0
 jupyter~=1.0
 jupyterlab==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ six~=1.15.0 # Required version for TF 2.4.1
 kedro==0.17.0
 gcsfs<2022.3 # Needed to access Google Cloud Storage files
 fsspec<2022.3 # Needed for DataSet functionality
-MarkupSafe<2.0.0 # Required version for 'cookiecutter' (a 'kedro' dependency)
+MarkupSafe <2.1.0 # Last version to include 'soft_unicode'
 Jinja2<3.0.0 # Required version for 'cookiecutter' (a 'kedro' dependency)
 
 # Testing/Linting


### PR DESCRIPTION
A dependency conflict when trying to install the Jupyter notebook
plugins required bumping the limit for MarkupSafe (but not too
much to avoid a breaking change in v2.1, where the removed
soft_unicode), and bumping the minimum for setuptools as required
by whatever version of ipykernel we're using.